### PR TITLE
Implemented the C backend for inline assembly

### DIFF
--- a/src/thorin/be/c.cpp
+++ b/src/thorin/be/c.cpp
@@ -922,10 +922,10 @@ std::ostream& CCodeGen::emit(const Def* def) {
         return func_impl_;
     }
 
-    if (auto asm_op = def->isa<Assembly>()) {
-        size_t out_size = asm_op->type()->num_args() - 1;
+    if (auto assembly = def->isa<Assembly>()) {
+        size_t out_size = assembly->type()->num_args() - 1;
         Array<std::string> outputs(out_size, "");
-        for (auto use : asm_op->uses()) {
+        for (auto use : assembly->uses()) {
             // TODO: this way of figuring out what index an output belongs to
             // is a bit cumbersome, is there a better way?
             auto extract = use->as<Extract>();
@@ -936,32 +936,29 @@ std::ostream& CCodeGen::emit(const Def* def) {
             assert(outputs[index - 1] == "" && "Each use must belong to a unique index.");
             auto name = extract->unique_name();
             outputs[index - 1] = name;
-            emit_type(func_impl_, asm_op->type()->arg(index)) << " " << name << ";" << endl;
+            emit_type(func_impl_, assembly->type()->arg(index)) << " " << name << ";" << endl;
         }
         // some outputs that were originally there might have been pruned because
         // they are not used but we still need them as operands for the asm
         // statement so we need to generate them here
         for (size_t i = 0; i < out_size; ++i) {
             if (outputs[i] == "") {
-                // TODO: is this a good way to construct unique names?
-                // we don't care about the output, we just need a name
-                // Would asm_op->unique_name() + "_" + i be better?
-                auto name = asm_op->out(i)->unique_name();
-                emit_type(func_impl_, asm_op->type()->arg(i + 1)) << " " << name << ";" << endl;
+                auto name = assembly->unique_name() + "_" + std::to_string(i + 1);
+                emit_type(func_impl_, assembly->type()->arg(i + 1)) << " " << name << ";" << endl;
                 outputs[i] = name;
             }
         }
 
         func_impl_ << "asm ";
-        if (asm_op->has_sideeffects())
-            func_impl_ << "__volatile__ ";
-        if (asm_op->is_alignstack() || asm_op->is_inteldialect())
-            WLOG("stack alignment and inteldialect flags unsupported for C output at %", asm_op->loc());
-        func_impl_ << "(\"" << asm_op->asm_template() << "\"";
+        if (assembly->has_sideeffects())
+            func_impl_ << "volatile ";
+        if (assembly->is_alignstack() || assembly->is_inteldialect())
+            WLOG("stack alignment and inteldialect flags unsupported for C output at %", assembly->loc());
+        func_impl_ << "(\"" << assembly->asm_template() << "\"";
    
         // emit the outputs 
         const char* separator = " : ";
-        auto out_constraints = asm_op->out_constraints();
+        auto out_constraints = assembly->out_constraints();
         for (size_t i = 0; i < out_constraints.size(); ++i) {
             func_impl_ << separator << "\"" << out_constraints[i] << "\"("
                 << outputs[i] << ")";
@@ -970,16 +967,16 @@ std::ostream& CCodeGen::emit(const Def* def) {
 
         // emit the inputs
         separator = out_constraints.empty() ? " :: " : " : ";
-        auto in_constraints = asm_op->in_constraints();
+        auto in_constraints = assembly->in_constraints();
         for (size_t i = 0; i < in_constraints.size(); ++i) {
             func_impl_ << separator << "\"" << in_constraints[i] << "\"(";
-            emit(asm_op->op(i + 1)) << ")";
+            emit(assembly->op(i + 1)) << ")";
             separator = ", ";
         }
 
         // emit the clobbers
         separator = in_constraints.empty() ? out_constraints.empty() ? " ::: " : " :: " : " : ";
-        for (auto clob : asm_op->clobbers()) {
+        for (auto clob : assembly->clobbers()) {
             func_impl_ << separator << "\"" << clob << "\"";
             separator = ", ";
         }

--- a/src/thorin/primop.h
+++ b/src/thorin/primop.h
@@ -609,6 +609,11 @@ private:
     friend class World;
 };
 
+inline Assembly::Flags operator|(Assembly::Flags lhs, Assembly::Flags rhs) { return static_cast<Assembly::Flags>(static_cast<int>(lhs) | static_cast<int>(rhs)); }
+inline Assembly::Flags operator&(Assembly::Flags lhs, Assembly::Flags rhs) { return static_cast<Assembly::Flags>(static_cast<int>(lhs) & static_cast<int>(rhs)); }
+inline Assembly::Flags operator|=(Assembly::Flags& lhs, Assembly::Flags rhs) { return lhs = lhs | rhs; }
+inline Assembly::Flags operator&=(Assembly::Flags& lhs, Assembly::Flags rhs) { return lhs = lhs & rhs; }
+
 //------------------------------------------------------------------------------
 
 template<int i, class T>

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -752,11 +752,11 @@ const Def* World::global_immutable_string(const Location& loc, const std::string
     return global(definite_array(str_array, loc), loc, false, name);
 }
 
-const Def* World::assembly(const Type* type, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Assembly::Flags flags, const Location& loc) {
-    return cse(new Assembly(type, inputs, asm_template, output_constraints, input_constraints, clobbers, flags, loc));
+const Assembly* World::assembly(const Type* type, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Assembly::Flags flags, const Location& loc) {
+    return cse(new Assembly(type, inputs, asm_template, output_constraints, input_constraints, clobbers, flags, loc))->as<Assembly>();;
 }
 
-const Def* World::assembly(Types types, const Def* mem, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Assembly::Flags flags, const Location& loc) {
+const Assembly* World::assembly(Types types, const Def* mem, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Assembly::Flags flags, const Location& loc) {
     Array<const Type*> output(types.size()+1);
     std::copy(types.begin(), types.end(), output.begin()+1);
     output.front() = mem_type();

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -166,8 +166,8 @@ public:
     const Def* global(const Def* init, const Location& loc, bool is_mutable = true, const std::string& name = "");
     const Def* global_immutable_string(const Location& loc, const std::string& str, const std::string& name = "");
     const Def* lea(const Def* ptr, const Def* index, const Location& loc, const std::string& name = "") { return cse(new LEA(ptr, index, loc, name)); }
-    const Def* assembly(const Type* type, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Assembly::Flags flags, const Location& loc);
-    const Def* assembly(Types types, const Def* mem, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Assembly::Flags flags, const Location& loc);
+    const Assembly* assembly(const Type* type, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Assembly::Flags flags, const Location& loc);
+    const Assembly* assembly(Types types, const Def* mem, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Assembly::Flags flags, const Location& loc);
 
     // guided partial evaluation
 


### PR DESCRIPTION
Also contains overloaded operators for Assembly::Flags that are needed in Impala as well.

This should not be merged right away because I first want to have some tests for emitting inline assembly in CUDA to check that everything works.