### PR TITLE
llvm: assume ptrs have (at least) ABI alignment

### DIFF
--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -964,11 +964,21 @@ llvm::Value* CodeGen::emit_global(const Global* global) {
 }
 
 llvm::Value* CodeGen::emit_load(const Load* load) {
-    return irbuilder_.CreateLoad(lookup(load->ptr()));
+    auto irPtr = lookup(load->ptr());
+    auto layout = llvm::DataLayout(module_->getDataLayout());
+    unsigned ptrAlignment = layout.getABITypeAlignment(irPtr->getType()->getPointerElementType());
+    auto irLoad = irbuilder_.CreateLoad(irPtr);
+    irLoad->setAlignment(ptrAlignment);
+    return irLoad;
 }
 
 llvm::Value* CodeGen::emit_store(const Store* store) {
-    return irbuilder_.CreateStore(lookup(store->val()), lookup(store->ptr()));
+    auto irPtr = lookup(store->ptr());
+    auto layout = llvm::DataLayout(module_->getDataLayout());
+    unsigned ptrAlignment = layout.getABITypeAlignment(irPtr->getType()->getPointerElementType());
+    auto irStore = irbuilder_.CreateStore(lookup(store->val()), irPtr);
+    irStore->setAlignment(ptrAlignment);
+    return irStore;
 }
 
 llvm::Value* CodeGen::emit_lea(const LEA* lea) {


### PR DESCRIPTION
This patch sets the alignment of loads and stores in generated LLVM IR according to the target ABI.

I don't know whether ABI alignment is a valid assumption for Thorin codegen (thus this PR). However, this improves assembly for SX-Aurora (loads and stores are otherwise legalized down into byte loads and stores...).
