### PR TITLE
GCC fix and tiny cleanup

### DIFF
--- a/src/thorin/util/hash.h
+++ b/src/thorin/util/hash.h
@@ -176,13 +176,13 @@ public:
         {}
 
 #if THORIN_ENABLE_CHECKS
+        inline int id() const { return id_; }
         inline void verify() const { assert(table_->id_ == id_); }
         inline void verify(iterator_base i) const {
             assert(table_ == i.table_ && id_ == i.id_);(void)i;
             verify();
         }
 #else
-        int id() const { return 0; }
         inline void verify() const {}
         inline void verify(iterator_base) const {}
 #endif

--- a/src/thorin/util/hash.h
+++ b/src/thorin/util/hash.h
@@ -182,7 +182,7 @@ public:
             verify();
         }
 #else
-        int id() const { return id_; }
+        int id() const { return 0; }
         inline void verify() const {}
         inline void verify(iterator_base) const {}
 #endif

--- a/src/thorin/util/stream.cpp
+++ b/src/thorin/util/stream.cpp
@@ -27,6 +27,7 @@ Stream& Stream::fmt(const char* s) {
             case '}':
                 if (match2nd(next, s, '}')) continue;
                 assert(false && "unmatched/unescaped closing brace '}' in format string");
+                break;
             default:
                 (*this) << *s++;
         }

--- a/src/thorin/util/stream.h
+++ b/src/thorin/util/stream.h
@@ -166,12 +166,14 @@ Stream& Stream::fmt(const char* s, T&& t, Args&&... args) {
         case '}':
             if (match2nd(next, s, '}')) continue;
             assert(false && "unmatched/unescaped closing brace '}' in format string");
+            break;
         default:
             (*this) << *s++;
         }
     }
 
     assert(false && "invalid format string for 's'");
+    return *this;
 }
 
 template<class R, class F, bool rangei = false>

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -248,6 +248,9 @@ public:
         std::abort();
     }
 
+    // Ignore log
+    void ignore() {}
+
     template<class... Args> void idef(const Def* def, const char* fmt, Args&&... args) { log(LogLevel::Info, def->loc(), fmt, std::forward<Args&&>(args)...); }
     template<class... Args> void wdef(const Def* def, const char* fmt, Args&&... args) { log(LogLevel::Warn, def->loc(), fmt, std::forward<Args&&>(args)...); }
     template<class... Args> void edef(const Def* def, const char* fmt, Args&&... args) { error(def->loc(), fmt, std::forward<Args&&>(args)...); }
@@ -306,7 +309,7 @@ private:
 #ifndef NDEBUG
 #define DLOG(...) log(thorin::LogLevel::Debug,   thorin::Loc(__FILE__, {__LINE__, thorin::u32(-1)}, {__LINE__, thorin::u32(-1)}), __VA_ARGS__)
 #else
-#define DLOG(...) do {} while (false)
+#define DLOG(...) ignore()
 #endif
 
 #endif


### PR DESCRIPTION
Fix of the issue #111 and fix for the Preprocessor definition of `DLOG`, which, with `NDEBUG` defined, does produces incorrect code.

Also cleaned up some "function does not return value" and "switch case break" issues. Keep in mind that those "fixes" do not change program flow or any other logic, as all the "fixes" appear after asserts, which should trigger an `abort` anyway. They are only there to please the compiler.