### PR TITLE
Fix PrimType mapping in C backend

### DIFF
--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -464,13 +464,13 @@ void CCodeGen::emit_module() {
         stream_.fmt("}} /* extern \"C\" */\n");
 }
 
-inline bool is_passed_via_buffer(const Param* param) {
+static inline bool is_passed_via_buffer(const Param* param) {
     return param->type()->isa<DefiniteArrayType>()
         || param->type()->isa<StructType>()
         || param->type()->isa<TupleType>();
 }
 
-inline const Type* ret_type(const FnType* fn_type) {
+static inline const Type* ret_type(const FnType* fn_type) {
     auto ret_fn_type = (*std::find_if(
         fn_type->ops().begin(), fn_type->ops().end(), [] (const Type* op) {
             return op->order() % 2 == 1;
@@ -592,7 +592,7 @@ void CCodeGen::prepare(Continuation* cont, const std::string&) {
     }
 }
 
-inline std::string make_identifier(const std::string& str) {
+static inline std::string make_identifier(const std::string& str) {
     auto copy = str;
     // Transform non-alphanumeric characters
     std::transform(copy.begin(), copy.end(), copy.begin(), [] (auto c) {
@@ -606,7 +606,7 @@ inline std::string make_identifier(const std::string& str) {
     return copy;
 }
 
-inline std::string label_name(const Def* def) {
+static inline std::string label_name(const Def* def) {
     return make_identifier(def->as_continuation()->unique_name());
 }
 

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -1497,6 +1497,17 @@ void CCodeGen::emit_c_int() {
     stream_.fmt("extern \"C\" {{\n");
     stream_.fmt("#endif\n\n");
 
+    stream_.fmt("typedef   int8_t  i8;\n"
+                "typedef  uint8_t  u8;\n"
+                "typedef  int16_t i16;\n"
+                "typedef uint16_t u16;\n"
+                "typedef  int32_t i32;\n"
+                "typedef uint32_t u32;\n"
+                "typedef  int64_t i64;\n"
+                "typedef uint64_t u64;\n"
+                "typedef    float f32;\n"
+                "typedef   double f64;\n\n");
+
     if (!type_decls_.str().empty())
         stream_.fmt("{}\n", type_decls_.str());
     if (!func_decls_.str().empty())

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -430,6 +430,16 @@ void CCodeGen::emit_module() {
             stream_.fmt("#include <stdlib.h>\n");   // for 'malloc'
         if (use_math_)
             stream_.fmt("#include <math.h>\n");     // for 'cos'/'sin'/...
+    }
+
+    if (lang_ == Lang::HLS) {
+        stream_.fmt("#include <hls_stream.h>\n"
+                    "#include <hls_math.h>\n");
+        if (use_fp_16_)
+            stream_.fmt("#include <hls_half.h>\n");
+    }
+
+    if (lang_ == Lang::C99 || lang_ == Lang::HLS) {
         stream_.fmt(    "\n"
                         "typedef   int8_t  i8;\n"
                         "typedef  uint8_t  u8;\n"
@@ -442,6 +452,9 @@ void CCodeGen::emit_module() {
                         "typedef    float f32;\n"
                         "typedef   double f64;\n"
                         "\n");
+
+         if (use_fp_16_ && lang_ == Lang::HLS)
+            stream_.fmt("typedef     half f16;\n");
     }
 
     if (lang_ == Lang::CUDA) {
@@ -466,9 +479,6 @@ void CCodeGen::emit_module() {
                         "typedef             double f64;\n"
                         "\n");
     }
-
-    if (lang_ == Lang::HLS)
-        stream_ << "#include \"hls_stream.h\""<< "\n" << "#include \"hls_math.h\""<< "\n";
 
     if (lang_ == Lang::CUDA || lang_ == Lang::HLS) {
         stream_.fmt("extern \"C\" {{\n");

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -145,7 +145,7 @@ private:
 
 static inline const std::string lang_as_string(Lang lang) {
     switch (lang) {
-        default:
+        default:     THORIN_UNREACHABLE;
         case Lang::C99:    return "C99";
         case Lang::HLS:    return "HLS";
         case Lang::CUDA:   return "CUDA";

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -851,7 +851,7 @@ const Def* World::transcendental(MathOpTag tag, const Def* left, const Def* righ
 }
 
 template <class F>
-inline bool float_predicate(const PrimLit* lit, F&& f) {
+static inline bool float_predicate(const PrimLit* lit, F&& f) {
     switch (lit->primtype_tag()) {
         case PrimType_qf16:
         case PrimType_pf16:


### PR DESCRIPTION
The C backend currently performs an unconditional mapping of the fixed-width PrimTypes to fundamental types in C. However, the exact sizes of fundamental types in C are implementation-defined and generally depend on the ABI of the target platform. For example, the C backend in its current form will always map `u64` to `long`. This would result in potentially incorrect codegen on Windows since `long` is a 32-Bit type in the Windows ABI. While `long` is a 64-Bit type under *some* circumstances in CUDA, it isn't a 64-Bit type under all circumstances (potentially depends on the host compiler). CUDA generally uses `long long` as its 64-Bit integer type. In addition to the potential problems noted before, the use of  `long` here results in code that uses 64-Bit integer atomics failing to compile since CUDA only has overloads for `unsigned long long` for 64-Bit atomics, none for `unsigned long`.

After some discussion on Discord, it was decided that the best way to fix this would be to emit a preamble of typedefs to perform the mapping to the appropriate fundamental types depending on the target C dialect. For plain standard C, we emit typedefs that map to the <stdint.h> fixed-width integer types. We also only map `f32` and `f64` if `__STDC_IEC_559__` is defined since there are otherwise no guarantees that `float` and `double` are the appropriate IEEE 754 floating point types. For OpenCL and CUDA, we perform the mapping according to the guaranteed sizes as noted in the respective specification/documentation.

This pull request delivers a proposed implementation of this fix.
