### PR TITLE
Allow compiling with debug but no checks

### DIFF
--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -333,7 +333,7 @@ private:
     template<class T, class... Args>
     T* put(Args&&... args) {
         auto def = new T(args...);
-#ifndef NDEBUG
+#if !defined(NDEBUG) && THORIN_ENABLE_CHECKS
         if (state_.breakpoints.contains(def->gid())) THORIN_BREAK;
 #endif
         auto p = data_.defs_.emplace(def);


### PR DESCRIPTION
Just a quick bugfix. I detected that bug randomly. Maybe replace the `NDEBUG` check completely and only relay on `THORIN_ENABLE_CHECKS`.
Without the fix thorin will not compile in build environments where neither `NDEBUG` nor `THORIN_ENABLE_CHECKS` is defined. 

Remark: I have no idea why someone would do this configuration, but the current source is not handling this case.