### PR TITLE
Unify Def and Type

### DIFF
--- a/src/thorin/analyses/free_defs.cpp
+++ b/src/thorin/analyses/free_defs.cpp
@@ -23,7 +23,7 @@ DefSet free_defs(const Scope& scope, bool include_closures) {
 
     while (!queue.empty()) {
         auto def = pop(queue);
-        if (def->isa_structural()) {
+        if (def->isa_structural() && !def->isa<Param>()) {
             if (!include_closures && def->isa<Closure>()) {
                 result.emplace(def);
                 queue.push(def->op(1));

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -218,7 +218,7 @@ std::string CCodeGen::convert(const Type* type) {
     StringStream s;
     std::string name;
 
-    if (type == world().unit() || type->isa<MemType>() || type->isa<FrameType>())
+    if (type == world().unit_type() || type->isa<MemType>() || type->isa<FrameType>())
         s << "void";
     else if (auto primtype = type->isa<PrimType>()) {
         switch (primtype->primtype_tag()) {
@@ -252,7 +252,7 @@ std::string CCodeGen::convert(const Type* type) {
     } else if (auto tuple = type->isa<TupleType>()) {
         name = tuple_name(tuple);
         s.fmt("typedef struct {{\t\n");
-        s.rangei(tuple->ops(), "\n", [&](size_t i) { s.fmt("{} e{};", convert(tuple->op(i)), i); });
+        s.rangei(tuple->ops(), "\n", [&](size_t i) { s.fmt("{} e{};", convert(tuple->types()[i]), i); });
         s.fmt("\b\n}} {};\n", name);
     } else if (auto variant = type->isa<VariantType>()) {
         types_[variant] = name = variant->name().str();
@@ -267,9 +267,9 @@ std::string CCodeGen::convert(const Type* type) {
         if (variant->has_payload()) {
             s.fmt("union {{\t\n");
             s.rangei(variant->ops(), "\n", [&] (size_t i) {
-                if (is_type_unit(variant->op(i)))
+                if (is_type_unit(variant->types()[i]))
                     s << "// ";
-                s.fmt("{} {};", convert(variant->op(i)), variant->op_name(i));
+                s.fmt("{} {};", convert(variant->types()[i]), variant->op_name(i));
             });
             s.fmt("\b\n}} data;\n");
         }
@@ -281,14 +281,14 @@ std::string CCodeGen::convert(const Type* type) {
         if ((lang_ == Lang::OpenCL || lang_ == Lang::HLS) && is_channel_type(struct_type))
             use_channels_ = true;
         if (lang_ == Lang::OpenCL && use_channels_) {
-            s.fmt("typedef {} {}_{};\n", convert(struct_type->op(0)), name, struct_type->gid());
+            s.fmt("typedef {} {}_{};\n", convert(struct_type->types()[0]), name, struct_type->gid());
             name = (struct_type->name().str() + "_" + std::to_string(type->gid()));
         } else if (is_channel_type(struct_type) && lang_ == Lang::HLS) {
-            s.fmt("typedef {} {}_{};\n", convert(struct_type->op(0)), name, struct_type->gid());
+            s.fmt("typedef {} {}_{};\n", convert(struct_type->types()[0]), name, struct_type->gid());
             name = ("hls::stream<" + name + "_" + std::to_string(type->gid()) + ">");
         } else {
             s.fmt("typedef struct {{\t\n");
-            s.rangei(struct_type->ops(), "\n", [&] (size_t i) { s.fmt("{} {};", convert(struct_type->op(i)), struct_type->op_name(i)); });
+            s.rangei(struct_type->ops(), "\n", [&] (size_t i) { s.fmt("{} {};", convert(struct_type->types()[i]), struct_type->op_name(i)); });
             s.fmt("\b\n}} {};\n", name);
         }
     } else {
@@ -526,15 +526,15 @@ static inline bool is_passed_via_buffer(const Param* param) {
 
 static inline const Type* ret_type(const FnType* fn_type) {
     auto ret_fn_type = (*std::find_if(
-        fn_type->ops().begin(), fn_type->ops().end(), [] (const Type* op) {
+        fn_type->types().begin(), fn_type->types().end(), [] (const Type* op) {
             return op->order() % 2 == 1;
         }))->as<FnType>();
     std::vector<const Type*> types;
-    for (auto op : ret_fn_type->ops()) {
+    for (auto op : ret_fn_type->types()) {
         if (op->isa<MemType>() || is_type_unit(op) || op->order() > 0) continue;
         types.push_back(op);
     }
-    return fn_type->table().tuple_type(types);
+    return fn_type->world().tuple_type(types);
 }
 
 static inline const Type* pointee_or_elem_type(const PtrType* ptr_type) {
@@ -913,12 +913,12 @@ std::string CCodeGen::emit_bottom(const Type* type) {
         StringStream s;
         s.fmt("{} ", constructor_prefix(type));
         s << "{ ";
-        s.range(type->ops(), ", ", [&] (const Type* op) { s << emit_bottom(op); });
+        s.range(type->ops(), ", ", [&] (const Def* op) { s << emit_bottom(op->as<Type>()); });
         s << " }";
         return s.str();
     } else if (auto variant_type = type->isa<VariantType>()) {
         if (variant_type->has_payload()) {
-            auto non_unit = *std::find_if(variant_type->ops().begin(), variant_type->ops().end(),
+            auto non_unit = *std::find_if(variant_type->types().begin(), variant_type->types().end(),
                 [] (const Type* op) { return !is_type_unit(op); });
             return constructor_prefix(type) + " { { " + emit_bottom(non_unit) + " }, 0 }";
         }
@@ -1252,7 +1252,7 @@ std::string CCodeGen::emit_def(BB* bb, const Def* def) {
         if (auto tup = ass->type()->isa<TupleType>()) {
             for (size_t i = 1, e = tup->num_ops(); i != e; ++i) {
                 auto name = ass->out(i)->unique_name();
-                func_impls_.fmt("{} {};\n", convert(tup->op(i)), name);
+                func_impls_.fmt("{} {};\n", convert(tup->types()[i]), name);
                 func_defs_.insert(ass->out(i));
                 outputs.emplace_back(name);
                 defs_[ass->out(i)] = name;
@@ -1465,10 +1465,10 @@ void CCodeGen::emit_c_int() {
             continue;
 
         // Generate C types for structs used by imported or exported functions
-        for (auto op : cont->type()->ops()) {
+        for (auto op : cont->type()->types()) {
             if (auto fn_type = op->isa<FnType>()) {
                 // Convert the return types as well (those are embedded in return continuations)
-                for (auto other_op : fn_type->ops()) {
+                for (auto other_op : fn_type->types()) {
                     if (!other_op->isa<FnType>())
                         convert(other_op);
                 }

--- a/src/thorin/be/c/c.h
+++ b/src/thorin/be/c/c.h
@@ -16,8 +16,8 @@ enum class Lang : uint8_t { C99, HLS, CUDA, OpenCL };
 
 class CodeGen : public thorin::CodeGen {
 public:
-    CodeGen(World& world, const Cont2Config& kernel_config, Lang lang, bool debug, std::string& flags)
-        : thorin::CodeGen(world, debug)
+    CodeGen(Thorin& thorin, const Cont2Config& kernel_config, Lang lang, bool debug, std::string& flags)
+        : thorin::CodeGen(thorin, debug)
         , kernel_config_(kernel_config)
         , lang_(lang)
         , debug_(debug)
@@ -43,7 +43,7 @@ private:
     std::string flags_;
 };
 
-void emit_c_int(World&, Stream& stream);
+void emit_c_int(Thorin&, Stream& stream);
 
 }
 

--- a/src/thorin/be/codegen.cpp
+++ b/src/thorin/be/codegen.cpp
@@ -13,14 +13,14 @@
 namespace thorin {
 
 static void get_kernel_configs(
-    Importer& importer,
+    Thorin& thorin,
     const std::vector<Continuation*>& kernels,
     Cont2Config& kernel_configs,
     std::function<std::unique_ptr<KernelConfig> (Continuation*, Continuation*)> use_callback)
 {
-    importer.world().opt();
+    thorin.opt();
 
-    auto externals = importer.world().externals();
+    auto externals = thorin.world().externals();
     for (auto continuation : kernels) {
         // recover the imported continuation (lost after the call to opt)
         Continuation* imported = nullptr;
@@ -78,8 +78,11 @@ static uint64_t get_alloc_size(const Def* def) {
 DeviceBackends::DeviceBackends(World& world, int opt, bool debug, std::string& flags)
     : cgs {}
 {
-    for (size_t i = 0; i < cgs.size(); ++i)
-        importers_.emplace_back(world);
+    std::vector<Importer> importers;
+    for (auto& name : backend_names) {
+        accelerator_code.emplace_back(name);
+        importers.emplace_back(world, accelerator_code.back().world());
+    }
 
     // determine different parts of the world which need to be compiled differently
     Scope::for_each(world, [&] (const Scope& scope) {
@@ -95,7 +98,7 @@ DeviceBackends::DeviceBackends(World& world, int opt, bool debug, std::string& f
         };
         for (auto [backend, intrinsic] : backend_intrinsics) {
             if (is_passed_to_intrinsic(continuation, intrinsic)) {
-                imported = importers_[backend].import(continuation)->as_nom<Continuation>();
+                imported = importers[backend].import(continuation)->as_nom<Continuation>();
                 break;
             }
         }
@@ -113,8 +116,8 @@ DeviceBackends::DeviceBackends(World& world, int opt, bool debug, std::string& f
     });
 
     for (auto backend : std::array { CUDA, NVVM, OpenCL, AMDGPU }) {
-        if (!importers_[backend].world().empty()) {
-            get_kernel_configs(importers_[backend], kernels, kernel_config, [&](Continuation *use, Continuation * /* imported */) {
+        if (!accelerator_code[backend].world().empty()) {
+            get_kernel_configs(accelerator_code[backend], kernels, kernel_config, [&](Continuation *use, Continuation * /* imported */) {
                 auto app = use->body();
                 // determine whether or not this kernel uses restrict pointers
                 bool has_restrict = true;
@@ -146,10 +149,10 @@ DeviceBackends::DeviceBackends(World& world, int opt, bool debug, std::string& f
     // get the HLS kernel configurations
     Top2Kernel top2kernel;
     DeviceParams hls_host_params;
-    if (!importers_[HLS].world().empty()) {
-        hls_host_params = hls_channels(importers_[HLS], top2kernel, world);
+    if (!accelerator_code[HLS].world().empty()) {
+        hls_host_params = hls_channels(accelerator_code[HLS], importers[HLS], top2kernel, world);
 
-        get_kernel_configs(importers_[HLS], kernels, kernel_config, [&] (Continuation* use, Continuation* imported) {
+        get_kernel_configs(accelerator_code[HLS], kernels, kernel_config, [&] (Continuation* use, Continuation* imported) {
             auto app = use->body();
             HLSKernelConfig::Param2Size param_sizes;
             for (size_t i = hls_free_vars_offset, e = app->num_args(); i != e; ++i) {
@@ -180,22 +183,22 @@ DeviceBackends::DeviceBackends(World& world, int opt, bool debug, std::string& f
             }
             return std::make_unique<HLSKernelConfig>(param_sizes);
         });
-        hls_annotate_top(importers_[HLS].world(), top2kernel, kernel_config);
+        hls_annotate_top(importers[HLS].world(), top2kernel, kernel_config);
     }
     hls_kernel_launch(world, hls_host_params);
 
 #if THORIN_ENABLE_LLVM
-    if (!importers_[NVVM  ].world().empty()) cgs[NVVM  ] = std::make_unique<llvm::NVVMCodeGen  >(importers_[NVVM  ].world(), kernel_config,      debug);
-    if (!importers_[AMDGPU].world().empty()) cgs[AMDGPU] = std::make_unique<llvm::AMDGPUCodeGen>(importers_[AMDGPU].world(), kernel_config, opt, debug);
+    if (!accelerator_code[NVVM  ].world().empty()) cgs[NVVM  ] = std::make_unique<llvm::NVVMCodeGen  >(accelerator_code[NVVM  ], kernel_config,      debug);
+    if (!accelerator_code[AMDGPU].world().empty()) cgs[AMDGPU] = std::make_unique<llvm::AMDGPUCodeGen>(accelerator_code[AMDGPU], kernel_config, opt, debug);
 #else
     (void)opt;
 #endif
     for (auto [backend, lang] : std::array { std::pair { CUDA, c::Lang::CUDA }, std::pair { OpenCL, c::Lang::OpenCL }, std::pair { HLS, c::Lang::HLS } })
-        if (!importers_[backend].world().empty()) cgs[backend] = std::make_unique<c::CodeGen>(importers_[backend].world(), kernel_config, lang, debug, flags);
+        if (!accelerator_code[backend].world().empty()) cgs[backend] = std::make_unique<c::CodeGen>(accelerator_code[backend], kernel_config, lang, debug, flags);
 }
 
-CodeGen::CodeGen(World& world, bool debug)
-    : world_(world)
+CodeGen::CodeGen(Thorin& thorin, bool debug)
+    : thorin_(thorin)
     , debug_(debug)
 {}
 

--- a/src/thorin/be/codegen.h
+++ b/src/thorin/be/codegen.h
@@ -8,7 +8,7 @@ namespace thorin {
 
 class CodeGen {
 protected:
-    CodeGen(World& world, bool debug);
+    CodeGen(Thorin& thorin, bool debug);
 public:
     virtual ~CodeGen() {}
 
@@ -17,12 +17,13 @@ public:
 
     /// @name getters
     //@{
-    World& world() const { return world_; }
+    Thorin& thorin() const { return thorin_; }
+    World& world() const { return thorin().world(); }
     bool debug() const { return debug_; }
     //@}
 
 private:
-    World& world_;
+    Thorin& thorin_;
     bool debug_;
 };
 
@@ -47,7 +48,8 @@ struct DeviceBackends {
     enum { CUDA, NVVM, OpenCL, AMDGPU, HLS, BackendCount };
     std::array<std::unique_ptr<CodeGen>, BackendCount> cgs;
 private:
-    std::vector<Importer> importers_;
+    std::array<const char*, BackendCount> backend_names = { "CUDA", "NVVM", "OpenCL", "AMDGPU", "HLS" };
+    std::vector<Thorin> accelerator_code;
 };
 
 }

--- a/src/thorin/be/emitter.h
+++ b/src/thorin/be/emitter.h
@@ -66,7 +66,7 @@ protected:
 
     Scheduler scheduler_;
     DefMap<Value> defs_;
-    TypeMap<Type> types_;
+    DefMap<Type> types_;
     ContinuationMap<BB> cont2bb_;
     Continuation* entry_ = nullptr;
 };

--- a/src/thorin/be/llvm/amdgpu.cpp
+++ b/src/thorin/be/llvm/amdgpu.cpp
@@ -7,8 +7,8 @@
 
 namespace thorin::llvm {
 
-AMDGPUCodeGen::AMDGPUCodeGen(World& world, const Cont2Config& kernel_config, int opt, bool debug)
-    : CodeGen(world, llvm::CallingConv::C, llvm::CallingConv::C, llvm::CallingConv::AMDGPU_KERNEL, opt, debug)
+AMDGPUCodeGen::AMDGPUCodeGen(Thorin& thorin, const Cont2Config& kernel_config, int opt, bool debug)
+    : CodeGen(thorin, llvm::CallingConv::C, llvm::CallingConv::C, llvm::CallingConv::AMDGPU_KERNEL, opt, debug)
     , kernel_config_(kernel_config)
 {
     module().setDataLayout("e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7");

--- a/src/thorin/be/llvm/amdgpu.h
+++ b/src/thorin/be/llvm/amdgpu.h
@@ -13,7 +13,7 @@ namespace llvm = ::llvm;
 
 class AMDGPUCodeGen : public CodeGen {
 public:
-    AMDGPUCodeGen(World& world, const Cont2Config&, int opt, bool debug);
+    AMDGPUCodeGen(Thorin&, const Cont2Config&, int opt, bool debug);
 
     const char* file_ext() const override { return ".amdgpu"; }
 

--- a/src/thorin/be/llvm/cpu.cpp
+++ b/src/thorin/be/llvm/cpu.cpp
@@ -8,8 +8,8 @@
 
 namespace thorin::llvm {
 
-CPUCodeGen::CPUCodeGen(World& world, int opt, bool debug, std::string& target_triple, std::string& target_cpu, std::string& target_attr)
-    : CodeGen(world, llvm::CallingConv::C, llvm::CallingConv::C, llvm::CallingConv::C, opt, debug)
+CPUCodeGen::CPUCodeGen(Thorin& thorin, int opt, bool debug, std::string& target_triple, std::string& target_cpu, std::string& target_attr)
+    : CodeGen(thorin, llvm::CallingConv::C, llvm::CallingConv::C, llvm::CallingConv::C, opt, debug)
 {
     llvm::InitializeNativeTarget();
     auto triple_str = llvm::sys::getDefaultTargetTriple();

--- a/src/thorin/be/llvm/cpu.h
+++ b/src/thorin/be/llvm/cpu.h
@@ -9,7 +9,7 @@ namespace llvm = ::llvm;
 
 class CPUCodeGen : public CodeGen {
 public:
-    CPUCodeGen(World& world, int opt, bool debug, std::string& target_triple, std::string& target_cpu, std::string& target_attr);
+    CPUCodeGen(Thorin&, int opt, bool debug, std::string& target_triple, std::string& target_cpu, std::string& target_attr);
 
 protected:
     std::string get_alloc_name() const override { return "anydsl_alloc"; }

--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -42,14 +42,14 @@
 namespace thorin::llvm {
 
 CodeGen::CodeGen(
-    World& world,
+    Thorin& thorin,
     llvm::CallingConv::ID function_calling_convention,
     llvm::CallingConv::ID device_calling_convention,
     llvm::CallingConv::ID kernel_calling_convention,
     int opt, bool debug)
-    : thorin::CodeGen(world, debug)
+    : thorin::CodeGen(thorin, debug)
     , context_(std::make_unique<llvm::LLVMContext>())
-    , module_(std::make_unique<llvm::Module>(world.name(), context()))
+    , module_(std::make_unique<llvm::Module>(world().name(), context()))
     , opt_(opt)
     , dibuilder_(module())
     , function_calling_convention_(function_calling_convention)

--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -144,14 +144,14 @@ llvm::Type* CodeGen::convert(const Type* type) {
             auto fn = type->as<FnType>();
             llvm::Type* ret = nullptr;
             std::vector<llvm::Type*> ops;
-            for (auto op : fn->ops()) {
-                if (op->isa<MemType>() || op == world().unit()) continue;
+            for (auto op : fn->types()) {
+                if (op->isa<MemType>() || op == world().unit_type()) continue;
                 auto fn = op->isa<FnType>();
                 if (fn && !op->isa<ClosureType>()) {
                     assert(!ret && "only one 'return' supported");
                     std::vector<llvm::Type*> ret_types;
-                    for (auto fn_op : fn->ops()) {
-                        if (fn_op->isa<MemType>() || fn_op == world().unit()) continue;
+                    for (auto fn_op : fn->types()) {
+                        if (fn_op->isa<MemType>() || fn_op == world().unit_type()) continue;
                         ret_types.push_back(convert(fn_op));
                     }
                     if (ret_types.size() == 0)      ret = llvm::Type::getVoidTy(context());
@@ -185,7 +185,7 @@ llvm::Type* CodeGen::convert(const Type* type) {
 
             Array<llvm::Type*> llvm_types(struct_type->num_ops());
             for (size_t i = 0, e = llvm_types.size(); i != e; ++i)
-                llvm_types[i] = convert(struct_type->op(i));
+                llvm_types[i] = convert(struct_type->types()[i]);
             llvm_struct->setBody(llvm_ref(llvm_types));
             return llvm_struct;
         }
@@ -194,19 +194,20 @@ llvm::Type* CodeGen::convert(const Type* type) {
             auto tuple = type->as<TupleType>();
             Array<llvm::Type*> llvm_types(tuple->num_ops());
             for (size_t i = 0, e = llvm_types.size(); i != e; ++i)
-                llvm_types[i] = convert(tuple->op(i));
+                llvm_types[i] = convert(tuple->types()[i]);
             llvm_type = llvm::StructType::get(context(), llvm_ref(llvm_types));
             return types_[tuple] = llvm_type;
         }
 
         case Node_VariantType: {
+            auto variant_type = type->as<VariantType>();
             assert(type->num_ops() > 0);
             // Max alignment/size constraints respectively in the variant type alternatives dictate the ones to use for the overall type
             size_t max_align = 0, max_size = 0;
 
             auto layout = module().getDataLayout();
             llvm::Type* max_align_type;
-            for (auto op : type->ops()) {
+            for (auto op : variant_type->types()) {
                 auto op_type = convert(op);
                 size_t size  = layout.getTypeAllocSize(op_type);
                 size_t align = layout.getABITypeAlignment(op_type);
@@ -828,7 +829,7 @@ llvm::Value* CodeGen::emit_bb(BB& bb, const Def* def) {
     } else if (auto variant_extract = def->isa<VariantExtract>()) {
         auto variant_value = variant_extract->op(0);
         auto llvm_value    = emit(variant_value);
-        auto target_type   = variant_value->type()->op(variant_extract->index());
+        auto target_type   = variant_value->type()->op(variant_extract->index())->as<Type>();
         if (is_type_unit(target_type))
             return nullptr;
 
@@ -1081,15 +1082,15 @@ llvm::Value* CodeGen::emit_lea(llvm::IRBuilder<>& irbuilder, const LEA* lea) {
 
 llvm::Value* CodeGen::emit_assembly(llvm::IRBuilder<>& irbuilder, const Assembly* assembly) {
     emit_unsafe(assembly->mem());
-    auto out_type = assembly->type();
+    auto out_type = assembly->type()->isa<TupleType>();
     llvm::Type* res_type;
     bool mem_only = false;
 
-    if (out_type->isa<TupleType>()) {
+    if (out_type) {
         if (out_type->num_ops() == 2)
-            res_type = convert(assembly->type()->op(1));
+            res_type = convert(out_type->types()[1]);
         else
-            res_type = convert(world().tuple_type(assembly->type()->ops().skip_front()));
+            res_type = convert(world().tuple_type(out_type->types().skip_front()));
     } else {
         res_type = llvm::Type::getVoidTy(context());
         mem_only = true;

--- a/src/thorin/be/llvm/llvm.h
+++ b/src/thorin/be/llvm/llvm.h
@@ -28,7 +28,7 @@ using BB = std::pair<llvm::BasicBlock*, std::unique_ptr<llvm::IRBuilder<>>>;
 class CodeGen : public thorin::CodeGen, public thorin::Emitter<llvm::Value*, llvm::Type*, BB, CodeGen> {
 protected:
     CodeGen(
-        World& world,
+        Thorin&,
         llvm::CallingConv::ID function_calling_convention,
         llvm::CallingConv::ID device_calling_convention,
         llvm::CallingConv::ID kernel_calling_convention,

--- a/src/thorin/be/llvm/nvvm.cpp
+++ b/src/thorin/be/llvm/nvvm.cpp
@@ -54,7 +54,7 @@ static AddrSpace resolve_addr_space(const Def* def) {
 llvm::FunctionType* NVVMCodeGen::convert_fn_type(Continuation* continuation) {
     // skip non-global address-space parameters
     std::vector<const Type*> types;
-    for (auto type : continuation->type()->ops()) {
+    for (auto type : continuation->type()->types()) {
         if (auto ptr = type->isa<PtrType>())
             if (ptr->addr_space() == AddrSpace::Texture)
                 continue;

--- a/src/thorin/be/llvm/nvvm.cpp
+++ b/src/thorin/be/llvm/nvvm.cpp
@@ -19,8 +19,8 @@
 
 namespace thorin::llvm {
 
-NVVMCodeGen::NVVMCodeGen(World& world, const Cont2Config& kernel_config, bool debug)
-    : CodeGen(world, llvm::CallingConv::C, llvm::CallingConv::PTX_Device, llvm::CallingConv::PTX_Kernel, 0, debug)
+NVVMCodeGen::NVVMCodeGen(Thorin& thorin, const Cont2Config& kernel_config, bool debug)
+    : CodeGen(thorin, llvm::CallingConv::C, llvm::CallingConv::PTX_Device, llvm::CallingConv::PTX_Kernel, 0, debug)
     , kernel_config_(kernel_config)
 {
     auto triple = llvm::Triple(llvm::sys::getDefaultTargetTriple());

--- a/src/thorin/be/llvm/nvvm.h
+++ b/src/thorin/be/llvm/nvvm.h
@@ -13,7 +13,7 @@ namespace llvm = ::llvm;
 
 class NVVMCodeGen : public CodeGen {
 public:
-    NVVMCodeGen(World& world, const Cont2Config&, bool debug); // NVVM-specific optimizations are run in the runtime
+    NVVMCodeGen(Thorin&, const Cont2Config&, bool debug); // NVVM-specific optimizations are run in the runtime
 
     const char* file_ext() const override { return ".nvvm"; }
 

--- a/src/thorin/be/llvm/parallel.cpp
+++ b/src/thorin/be/llvm/parallel.cpp
@@ -36,7 +36,7 @@ Continuation* CodeGen::emit_parallel(llvm::IRBuilder<>& irbuilder, Continuation*
     }
 
     // fetch values and create a unified struct which contains all values (closure)
-    auto closure_type = convert(world().tuple_type(continuation->arg_fn_type()->ops().skip_front(PAR_NUM_ARGS)));
+    auto closure_type = convert(world().tuple_type(continuation->arg_fn_type()->types().skip_front(PAR_NUM_ARGS)));
     llvm::Value* closure = llvm::UndefValue::get(closure_type);
     if (num_kernel_args != 1) {
         for (size_t i = 0; i < num_kernel_args; ++i)
@@ -131,7 +131,7 @@ Continuation* CodeGen::emit_fibers(llvm::IRBuilder<>& irbuilder, Continuation* c
     }
 
     // fetch values and create a unified struct which contains all values (closure)
-    auto closure_type = convert(world().tuple_type(continuation->arg_fn_type()->ops().skip_front(FIB_NUM_ARGS)));
+    auto closure_type = convert(world().tuple_type(continuation->arg_fn_type()->types().skip_front(FIB_NUM_ARGS)));
     llvm::Value* closure = llvm::UndefValue::get(closure_type);
     if (num_kernel_args != 1) {
         for (size_t i = 0; i < num_kernel_args; ++i)
@@ -215,7 +215,7 @@ Continuation* CodeGen::emit_spawn(llvm::IRBuilder<>& irbuilder, Continuation* co
     }
 
     // fetch values and create a unified struct which contains all values (closure)
-    auto closure_type = convert(world().tuple_type(continuation->arg_fn_type()->ops().skip_front(SPAWN_NUM_ARGS)));
+    auto closure_type = convert(world().tuple_type(continuation->arg_fn_type()->types().skip_front(SPAWN_NUM_ARGS)));
     llvm::Value* closure = nullptr;
     if (closure_type->isStructTy()) {
         closure = llvm::UndefValue::get(closure_type);

--- a/src/thorin/be/llvm/runtime.cpp
+++ b/src/thorin/be/llvm/runtime.cpp
@@ -45,15 +45,15 @@ static bool contains_ptrtype(const Type* type) {
         case Node_StructType: {
             bool good = true;
             auto struct_type = type->as<StructType>();
-            for (size_t i = 0, e = struct_type->num_ops(); i != e; ++i)
-                good &= contains_ptrtype(struct_type->op(i));
+            for (auto& t : struct_type->types())
+                good &= contains_ptrtype(t);
             return good;
         }
         case Node_TupleType: {
             bool good = true;
             auto tuple = type->as<TupleType>();
-            for (size_t i = 0, e = tuple->num_ops(); i != e; ++i)
-                good &= contains_ptrtype(tuple->op(i));
+            for (auto& t : tuple->types())
+                good &= contains_ptrtype(t);
             return good;
         }
         default: return true;

--- a/src/thorin/continuation.cpp
+++ b/src/thorin/continuation.cpp
@@ -10,8 +10,8 @@ namespace thorin {
 
 //------------------------------------------------------------------------------
 
-Param::Param(const Type* type, Continuation* continuation, size_t index, Debug dbg)
-    : Def(Node_Param, type, 1, dbg)
+Param::Param(World& world, const Type* type, Continuation* continuation, size_t index, Debug dbg)
+    : Def(Node_Param, world, type, 1, dbg)
     , index_(index)
 {
     set_op(0, continuation);
@@ -19,7 +19,7 @@ Param::Param(const Type* type, Continuation* continuation, size_t index, Debug d
 
 //------------------------------------------------------------------------------
 
-App::App(const Defs ops, Debug dbg) : Def(Node_App, ops[0]->world().bottom_type(), ops, dbg) {
+App::App(World& world, const Defs ops, Debug dbg) : Def(Node_App, world, ops[0]->world().bottom_type(), ops, dbg) {
 #if THORIN_ENABLE_CHECKS
     verify();
     if (auto cont = callee()->isa_nom<Continuation>())
@@ -41,7 +41,7 @@ void App::verify() const {
 
 //------------------------------------------------------------------------------
 
-Filter::Filter(World& world, const Defs defs, Debug dbg) : Def(Node_Filter, world.bottom_type(), defs, dbg) {}
+Filter::Filter(World& world, const Defs defs, Debug dbg) : Def(Node_Filter, world, world.bottom_type(), defs, dbg) {}
 
 const Filter* Filter::cut(ArrayRef<size_t> indices) const {
     return world().filter(ops().cut(indices), debug());
@@ -49,8 +49,8 @@ const Filter* Filter::cut(ArrayRef<size_t> indices) const {
 
 //------------------------------------------------------------------------------
 
-Continuation::Continuation(const FnType* fn, const Attributes& attributes, Debug dbg)
-    : Def(Node_Continuation, fn, 2, dbg)
+Continuation::Continuation(World& w, const FnType* fn, const Attributes& attributes, Debug dbg)
+    : Def(Node_Continuation, w, fn, 2, dbg)
     , attributes_(attributes)
 {
     params_.reserve(fn->num_ops());

--- a/src/thorin/continuation.cpp
+++ b/src/thorin/continuation.cpp
@@ -10,16 +10,27 @@ namespace thorin {
 
 //------------------------------------------------------------------------------
 
-Param::Param(World& world, const Type* type, Continuation* continuation, size_t index, Debug dbg)
-    : Def(Node_Param, world, type, 1, dbg)
+Param::Param(World& world, const Type* type, const Continuation* continuation, size_t index, Debug dbg)
+    : Def(world, Node_Param, type, { continuation }, dbg)
     , index_(index)
-{
-    set_op(0, continuation);
+{}
+
+const Def* Param::rebuild(World& world, const Type* t, Defs defs) const {
+    assert(defs.size() == 1 && defs[0]->isa<Continuation>());
+    return world.param(t, defs[0]->as<Continuation>(), index(), debug());
+}
+
+hash_t Param::vhash() const {
+    return hash_combine(Def::vhash(), (hash_t) index());
+}
+
+bool Param::equal(const Def* other) const {
+    return Def::equal(other) && other->as<Param>()->index() == index();
 }
 
 //------------------------------------------------------------------------------
 
-App::App(World& world, const Defs ops, Debug dbg) : Def(Node_App, world, ops[0]->world().bottom_type(), ops, dbg) {
+App::App(World& world, const Defs ops, Debug dbg) : Def(world, Node_App, ops[0]->world().bottom_type(), ops, dbg) {
 #if THORIN_ENABLE_CHECKS
     verify();
     if (auto cont = callee()->isa_nom<Continuation>())
@@ -41,7 +52,7 @@ void App::verify() const {
 
 //------------------------------------------------------------------------------
 
-Filter::Filter(World& world, const Defs defs, Debug dbg) : Def(Node_Filter, world, world.bottom_type(), defs, dbg) {}
+Filter::Filter(World& world, const Defs defs, Debug dbg) : Def(world, Node_Filter, world.bottom_type(), defs, dbg) {}
 
 const Filter* Filter::cut(ArrayRef<size_t> indices) const {
     return world().filter(ops().cut(indices), debug());
@@ -49,16 +60,23 @@ const Filter* Filter::cut(ArrayRef<size_t> indices) const {
 
 //------------------------------------------------------------------------------
 
-Continuation::Continuation(World& w, const FnType* fn, const Attributes& attributes, Debug dbg)
-    : Def(Node_Continuation, w, fn, 2, dbg)
+Continuation::Continuation(World& w, const FnType* pi, const Attributes& attributes, Debug dbg)
+    : Def(w, Node_Continuation, pi, 2, dbg)
     , attributes_(attributes)
 {
-    params_.reserve(fn->num_ops());
+    params_.reserve(pi->num_ops());
     set_op(0, world().bottom(world().bottom_type()));
     set_op(1, world().filter({}, dbg));
+
+    size_t i = 0;
+    for (auto op : pi->types()) {
+        auto p = w.param(op, this, i++, dbg);
+        params_.emplace_back(p);
+    }
 }
 
-Continuation* Continuation::stub() const {
+// TODO: merge with regular stub()
+Continuation* Continuation::mangle_stub() const {
     Rewriter rewriter;
 
     auto result = world().continuation(type(), attributes(), debug_history());
@@ -76,6 +94,40 @@ Continuation* Continuation::stub() const {
     }
 
     return result;
+}
+
+Continuation* Continuation::stub(World& nworld, const Type* t) const {
+    assert(!dead_);
+    // TODO maybe we want to deal with intrinsics in a more streamlined way
+    if (this == world().branch())
+        return nworld.branch();
+    if (this == world().end_scope())
+        return nworld.end_scope();
+
+    auto npi = t->isa<FnType>();
+    assert(npi);
+    Continuation* ncontinuation = nworld.continuation(npi, attributes(), debug_history());
+    assert(&ncontinuation->world() == &nworld);
+    assert(&npi->world() == &nworld);
+    for (size_t i = 0, e = num_params(); i != e; ++i)
+        ncontinuation->param(i)->set_name(param(i)->debug_history().name);
+
+    if (is_external())
+        nworld.make_external(ncontinuation);
+    return ncontinuation;
+}
+
+void Continuation::rebuild_from(const Def*, Defs nops) {
+    if (this == world().branch())
+        return;
+    if (this == world().end_scope())
+        return;
+
+    auto napp = nops[0]->isa<App>();
+    if (napp)
+        set_body(napp);
+    set_filter(nops[1]->as<Filter>());
+    verify();
 }
 
 Array<const Def*> Continuation::params_as_defs() const {
@@ -126,9 +178,9 @@ const FnType* Continuation::arg_fn_type() const {
 const Param* Continuation::append_param(const Type* param_type, Debug dbg) {
     size_t size = type()->num_ops();
     Array<const Type*> ops(size + 1);
-    *std::copy(type()->ops().begin(), type()->ops().end(), ops.begin()) = param_type;
+    *std::copy(type()->types().begin(), type()->types().end(), ops.begin()) = param_type;
     clear_type();
-    set_type(param_type->table().fn_type(ops));              // update type
+    set_type(world().fn_type(ops));              // update type
     auto param = world().param(param_type, this, size, dbg); // append new param
     params_.push_back(param);
 

--- a/src/thorin/continuation.cpp
+++ b/src/thorin/continuation.cpp
@@ -12,12 +12,16 @@ namespace thorin {
 
 Param::Param(World& world, const Type* type, const Continuation* continuation, size_t index, Debug dbg)
     : Def(world, Node_Param, type, { continuation }, dbg)
+    //: Def(world, Node_Param, type, 1, dbg)
     , index_(index)
-{}
+{
+    //set_op(0, continuation);
+}
 
 const Def* Param::rebuild(World& world, const Type* t, Defs defs) const {
-    assert(defs.size() == 1 && defs[0]->isa<Continuation>());
-    return world.param(t, defs[0]->as<Continuation>(), index(), debug());
+    assert(defs.size() == 1);
+    auto cont = defs[0]->as<Continuation>();
+    return cont->param(index());
 }
 
 hash_t Param::vhash() const {

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -24,7 +24,7 @@ typedef std::vector<Continuation*> Continuations;
  */
 class Param : public Def {
 private:
-    Param(const Type* type, Continuation* continuation, size_t index, Debug dbg);
+    Param(World&, const Type* type, Continuation* continuation, size_t index, Debug dbg);
 
 public:
     Continuation* continuation() const { return op(0)->as_nom<Continuation>(); }
@@ -53,7 +53,7 @@ public:
 
 class App : public Def {
 private:
-    App(const Defs ops, Debug dbg);
+    App(World&, const Defs ops, Debug dbg);
 
 public:
     const Def* callee() const { return op(0); }
@@ -130,7 +130,7 @@ public:
     };
 
 private:
-    Continuation(const FnType* fn, const Attributes& attributes, Debug dbg);
+    Continuation(World&, const FnType* fn, const Attributes& attributes, Debug dbg);
     virtual ~Continuation() { for (auto param : params()) delete param; }
 
 public:

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -24,12 +24,15 @@ typedef std::vector<Continuation*> Continuations;
  */
 class Param : public Def {
 private:
-    Param(World&, const Type* type, Continuation* continuation, size_t index, Debug dbg);
+    Param(World&, const Type* type, const Continuation* continuation, size_t index, Debug dbg);
 
 public:
     Continuation* continuation() const { return op(0)->as_nom<Continuation>(); }
     size_t index() const { return index_; }
 
+    const Def * rebuild(World&, const Type*, Defs) const override;
+    bool equal(const Def*) const override;
+    hash_t vhash() const override;
 private:
     const size_t index_;
 
@@ -130,13 +133,15 @@ public:
     };
 
 private:
-    Continuation(World&, const FnType* fn, const Attributes& attributes, Debug dbg);
+    Continuation(World&, const FnType* pi, const Attributes& attributes, Debug dbg);
     virtual ~Continuation() { for (auto param : params()) delete param; }
 
 public:
     const FnType* type() const { return Def::type()->as<FnType>(); }
 
-    Continuation* stub() const;
+    Continuation* mangle_stub() const;
+    Continuation* stub(World&, const Type*) const override;
+    void rebuild_from(const Def* old, Defs new_ops) override;
     const Param* append_param(const Type* type, Debug dbg = {});
     Continuations preds() const;
     Continuations succs() const;

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -30,7 +30,7 @@ public:
     Continuation* continuation() const { return op(0)->as_nom<Continuation>(); }
     size_t index() const { return index_; }
 
-    const Def * rebuild(World&, const Type*, Defs) const override;
+    const Def* rebuild(World&, const Type*, Defs) const override;
     bool equal(const Def*) const override;
     hash_t vhash() const override;
 private:

--- a/src/thorin/def.cpp
+++ b/src/thorin/def.cpp
@@ -56,6 +56,7 @@ void Def::set_name(const std::string& name) const { debug_.name = name; }
 void Def::set_op(size_t i, const Def* def) {
     assert(!op(i) && "already set");
     assert(def && "setting null pointer");
+    assert(&def->world() == &world());
     ops_[i] = def;
     // A Param/Continuation should not have other bits than its own set.
     // (Right now, Param doesn't have ops, but this will change in the future).
@@ -136,6 +137,7 @@ bool is_minus_zero(const Def* def) {
 void Def::replace_uses(const Def* with) const {
     world().DLOG("replace uses: {} -> {}", this, with);
     if (this != with) {
+        assert(&with->world() == &this->world());
         for (auto& use : copy_uses()) {
             auto def = const_cast<Def*>(use.def());
             auto index = use.index();

--- a/src/thorin/def.cpp
+++ b/src/thorin/def.cpp
@@ -14,9 +14,10 @@ namespace thorin {
 
 size_t Def::gid_counter_ = 1;
 
-Def::Def(NodeTag tag, const Type* type, Defs ops, Debug dbg)
+Def::Def(NodeTag tag, World& world, const Type* type, Defs ops, Debug dbg)
     : tag_(tag)
     , ops_(ops.size())
+    , world_(world)
     , type_(type)
     , debug_(dbg)
     , gid_(gid_counter_++)
@@ -29,9 +30,10 @@ Def::Def(NodeTag tag, const Type* type, Defs ops, Debug dbg)
         set_op(i, ops[i]);
 }
 
-Def::Def(NodeTag tag, const Type* type, size_t size, Debug dbg)
+Def::Def(NodeTag tag, World& world, const Type* type, size_t size, Debug dbg)
     : tag_(tag)
     , ops_(size)
+    , world_(world)
     , type_(type)
     , debug_(dbg)
     , gid_(gid_counter_++)
@@ -145,7 +147,7 @@ void Def::replace_uses(const Def* with) const {
     }
 }
 
-World& Def::world() const { return *static_cast<World*>(&type()->table()); }
+World& Def::world() const { return world_; }
 
 uint64_t UseHash::hash(Use use) {
     assert(use->gid() != uint32_t(-1));

--- a/src/thorin/def.h
+++ b/src/thorin/def.h
@@ -157,7 +157,7 @@ public:
     //@{
     const Def* out(size_t i) const;
     bool empty() const { return ops_.empty(); }
-    void set_op(size_t i, const Def* def);
+    virtual void set_op(size_t i, const Def* def);
     void unset_op(size_t i);
     void unset_ops();
     virtual bool has_multiple_outs() const { return false; }

--- a/src/thorin/def.h
+++ b/src/thorin/def.h
@@ -106,9 +106,9 @@ private:
 
 protected:
     /// Constructor for a @em structural Def.
-    Def(NodeTag tag, const Type* type, Defs args, Debug dbg);
+    Def(NodeTag tag, World&, const Type* type, Defs args, Debug dbg);
     /// Constructor for a @em nom Def.
-    Def(NodeTag tag, const Type* type, size_t size, Debug);
+    Def(NodeTag tag, World&, const Type* type, size_t size, Debug);
     virtual ~Def() {}
 
     void clear_type() { type_ = nullptr; }
@@ -230,6 +230,7 @@ public:
 private:
     const NodeTag tag_;
     std::vector<const Def*> ops_;
+    World& world_;
     const Type* type_;
     mutable Uses uses_;
     mutable Debug debug_;

--- a/src/thorin/def.h
+++ b/src/thorin/def.h
@@ -5,8 +5,8 @@
 #include <vector>
 
 #include "thorin/enums.h"
-#include "thorin/type.h"
 #include "thorin/debug.h"
+#include "thorin/util/array.h"
 
 namespace thorin {
 
@@ -17,6 +17,7 @@ class Def;
 class Tracker;
 class Use;
 class World;
+class Type;
 
 typedef ArrayRef<const Def*> Defs;
 
@@ -76,6 +77,23 @@ struct UseHash {
 // using a StackCapacity of 8 covers almost 99% of all real-world use-lists
 typedef HashSet<Use, UseHash> Uses;
 
+template<class T>
+struct GIDLt {
+    bool operator()(T a, T b) const { return a->gid() < b->gid(); }
+};
+
+template<class T>
+struct GIDHash {
+    static hash_t hash(T n) { return thorin::murmur3(n->gid()); }
+    static bool eq(T a, T b) { return a == b; }
+    static T sentinel() { return T(1); }
+};
+
+template<class Key, class Value>
+using GIDMap = thorin::HashMap<Key, Value, GIDHash<Key>>;
+template<class Key>
+using GIDSet = thorin::HashSet<Key, GIDHash<Key>>;
+
 template<class To>
 using DefMap  = GIDMap<const Def*, To>;
 using DefSet  = GIDSet<const Def*>;
@@ -106,9 +124,9 @@ private:
 
 protected:
     /// Constructor for a @em structural Def.
-    Def(NodeTag tag, World&, const Type* type, Defs args, Debug dbg);
+    Def(World&, NodeTag tag, const Type* type, Defs args, Debug dbg);
     /// Constructor for a @em nom Def.
-    Def(NodeTag tag, World&, const Type* type, size_t size, Debug);
+    Def(World&, NodeTag tag, const Type* type, size_t size, Debug);
     virtual ~Def() {}
 
     void clear_type() { type_ = nullptr; }
@@ -122,7 +140,7 @@ public:
     //@{
     NodeTag tag() const { return tag_; }
     size_t gid() const { return gid_; }
-    World& world() const;
+    World& world() const { return world_; };
     //@}
 
     /// @name ops
@@ -155,7 +173,8 @@ public:
     /// @name type
     //@{
     const Type* type() const { return type_; }
-    int order() const { return type()->order(); }
+
+    virtual int order() const;
     //@}
 
     /// @name dependence checks
@@ -202,7 +221,8 @@ public:
     /// @name rebuild/stub
     //@{
     virtual const Def* rebuild(World&, const Type*, Defs) const { THORIN_UNREACHABLE; }
-    // TODO stub
+    virtual       Def* stub(World&, const Type*) const { THORIN_UNREACHABLE; }
+    virtual       void rebuild_from(const Def* old, Defs new_ops);
     //@}
 
     void replace_uses(const Def*) const;
@@ -251,7 +271,6 @@ size_t vector_length(const Def*);
 bool is_unit(const Def*);
 bool is_primlit(const Def*, int64_t);
 bool is_minus_zero(const Def*);
-inline bool is_mem        (const Def* def) { return def->type()->isa<MemType>(); }
 inline bool is_zero       (const Def* def) { return is_primlit(def, 0); }
 inline bool is_one        (const Def* def) { return is_primlit(def, 1); }
 inline bool is_allset     (const Def* def) { return is_primlit(def, -1); }

--- a/src/thorin/primop.cpp
+++ b/src/thorin/primop.cpp
@@ -246,32 +246,13 @@ const Def* IndefiniteArray::rebuild(World& w, const Type* t, Defs o) const {
 
 const char* Def::op_name() const {
     switch (tag()) {
+#define THORIN_GLUE(pre, next)
 #define THORIN_NODE(op, abbr) case Node_##op: return #abbr;
-#include "thorin/tables/nodetable.h"
-        default: THORIN_UNREACHABLE;
-    }
-}
-
-const char* ArithOp::op_name() const {
-    switch (tag()) {
+#define THORIN_PRIMTYPE(T) case Node_PrimType_##T: return #T;
 #define THORIN_ARITHOP(op) case ArithOp_##op: return #op;
-#include "thorin/tables/arithoptable.h"
-        default: THORIN_UNREACHABLE;
-    }
-}
-
-const char* Cmp::op_name() const {
-    switch (tag()) {
 #define THORIN_CMP(op) case Cmp_##op: return #op;
-#include "thorin/tables/cmptable.h"
-        default: THORIN_UNREACHABLE;
-    }
-}
-
-const char* MathOp::op_name() const {
-    switch (tag()) {
 #define THORIN_MATHOP(op) case MathOp_##op: return #op;
-#include "thorin/tables/mathoptable.h"
+#include "thorin/tables/allnodes.h"
         default: THORIN_UNREACHABLE;
     }
 }

--- a/src/thorin/primop.cpp
+++ b/src/thorin/primop.cpp
@@ -15,16 +15,16 @@ namespace thorin {
  */
 
 PrimLit::PrimLit(World& world, PrimTypeTag tag, Box box, Debug dbg)
-    : Literal((NodeTag) tag, world.prim_type(tag), dbg)
+    : Literal((NodeTag) tag, world, world.prim_type(tag), dbg)
     , box_(box)
 {}
 
-Cmp::Cmp(CmpTag tag, const Def* lhs, const Def* rhs, Debug dbg)
-    : BinOp((NodeTag) tag, lhs->world().type_bool(vector_length(lhs->type())), lhs, rhs, dbg)
+Cmp::Cmp(CmpTag tag, World& world, const Def* lhs, const Def* rhs, Debug dbg)
+    : BinOp((NodeTag) tag, world, world.type_bool(vector_length(lhs->type())), lhs, rhs, dbg)
 {}
 
 DefiniteArray::DefiniteArray(World& world, const Type* elem, Defs args, Debug dbg)
-    : Aggregate(Node_DefiniteArray, args, dbg)
+    : Aggregate(Node_DefiniteArray, world, args, dbg)
 {
     set_type(world.definite_array_type(elem, args.size()));
 #if THORIN_ENABLE_CHECKS
@@ -34,13 +34,13 @@ DefiniteArray::DefiniteArray(World& world, const Type* elem, Defs args, Debug db
 }
 
 IndefiniteArray::IndefiniteArray(World& world, const Type* elem, const Def* dim, Debug dbg)
-    : Aggregate(Node_IndefiniteArray, {dim}, dbg)
+    : Aggregate(Node_IndefiniteArray, world, {dim}, dbg)
 {
     set_type(world.indefinite_array_type(elem));
 }
 
 Tuple::Tuple(World& world, Defs args, Debug dbg)
-    : Aggregate(Node_Tuple, args, dbg)
+    : Aggregate(Node_Tuple, world, args, dbg)
 {
     Array<const Type*> elems(num_ops());
     for (size_t i = 0, e = num_ops(); i != e; ++i)
@@ -50,7 +50,7 @@ Tuple::Tuple(World& world, Defs args, Debug dbg)
 }
 
 Vector::Vector(World& world, Defs args, Debug dbg)
-    : Aggregate(Node_Vector, args, dbg)
+    : Aggregate(Node_Vector, world, args, dbg)
 {
     if (auto primtype = args.front()->type()->isa<PrimType>()) {
         assert(primtype->length() == 1);
@@ -62,10 +62,9 @@ Vector::Vector(World& world, Defs args, Debug dbg)
     }
 }
 
-LEA::LEA(const Def* ptr, const Def* index, Debug dbg)
-    : Def(Node_LEA, nullptr, {ptr, index}, dbg)
+LEA::LEA(World& world, const Def* ptr, const Def* index, Debug dbg)
+    : Def(Node_LEA, world, nullptr, {ptr, index}, dbg)
 {
-    auto& world = index->world();
     auto type = ptr_type();
     if (auto tuple = ptr_pointee()->isa<TupleType>()) {
         set_type(world.ptr_type(get(tuple->ops(), index), type->length(), type->device(), type->addr_space()));
@@ -81,54 +80,51 @@ LEA::LEA(const Def* ptr, const Def* index, Debug dbg)
     }
 }
 
-Known::Known(const Def* def, Debug dbg)
-    : Def(Node_Known, def->world().type_bool(), {def}, dbg)
+Known::Known(World& world, const Def* def, Debug dbg)
+    : Def(Node_Known, world, world.type_bool(), {def}, dbg)
 {}
 
-AlignOf::AlignOf(const Def* def, Debug dbg)
-    : Def(Node_AlignOf, def->world().type_qs64(), {def}, dbg)
+AlignOf::AlignOf(World& world, const Def* def, Debug dbg)
+    : Def(Node_AlignOf, world, world.type_qs64(), {def}, dbg)
 {}
 
-SizeOf::SizeOf(const Def* def, Debug dbg)
-    : Def(Node_SizeOf, def->world().type_qs64(), {def}, dbg)
+SizeOf::SizeOf(World& world, const Def* def, Debug dbg)
+    : Def(Node_SizeOf, world, world.type_qs64(), {def}, dbg)
 {}
 
-Slot::Slot(const Type* type, const Def* frame, Debug dbg)
-    : Def(Node_Slot, type->table().ptr_type(type), {frame}, dbg)
+Slot::Slot(World& world, const Type* type, const Def* frame, Debug dbg)
+    : Def(Node_Slot, world, type->table().ptr_type(type), {frame}, dbg)
 {
     assert(frame->type()->isa<FrameType>());
 }
 
-Global::Global(const Def* init, bool is_mutable, Debug dbg)
-    : Def(Node_Global, init->type()->table().ptr_type(init->type()), {init}, dbg)
+Global::Global(World& world, const Def* init, bool is_mutable, Debug dbg)
+    : Def(Node_Global, world, init->type()->table().ptr_type(init->type()), {init}, dbg)
     , is_mutable_(is_mutable)
 {
     assert(!init->has_dep(Dep::Param));
 }
 
-Alloc::Alloc(const Type* type, const Def* mem, const Def* extra, Debug dbg)
-    : MemOp(Node_Alloc, nullptr, {mem, extra}, dbg)
+Alloc::Alloc(World& world, const Type* type, const Def* mem, const Def* extra, Debug dbg)
+    : MemOp(Node_Alloc, world, nullptr, {mem, extra}, dbg)
 {
-    World& w = mem->world();
-    set_type(w.tuple_type({w.mem_type(), w.ptr_type(type)}));
+    set_type(world.tuple_type({world.mem_type(), world.ptr_type(type)}));
 }
 
-Load::Load(const Def* mem, const Def* ptr, Debug dbg)
-    : Access(Node_Load, nullptr, {mem, ptr}, dbg)
+Load::Load(World& world, const Def* mem, const Def* ptr, Debug dbg)
+    : Access(Node_Load, world, nullptr, {mem, ptr}, dbg)
 {
-    World& w = mem->world();
-    set_type(w.tuple_type({w.mem_type(), ptr->type()->as<PtrType>()->pointee()}));
+    set_type(world.tuple_type({world.mem_type(), ptr->type()->as<PtrType>()->pointee()}));
 }
 
-Enter::Enter(const Def* mem, Debug dbg)
-    : MemOp(Node_Enter, nullptr, {mem}, dbg)
+Enter::Enter(World& world, const Def* mem, Debug dbg)
+    : MemOp(Node_Enter, world, nullptr, {mem}, dbg)
 {
-    World& w = mem->world();
-    set_type(w.tuple_type({w.mem_type(), w.frame_type()}));
+    set_type(world.tuple_type({world.mem_type(), world.frame_type()}));
 }
 
-Assembly::Assembly(const Type *type, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Flags flags, Debug dbg)
-    : MemOp(Node_Assembly, type, inputs, dbg)
+Assembly::Assembly(World& world, const Type *type, Defs inputs, std::string asm_template, ArrayRef<std::string> output_constraints, ArrayRef<std::string> input_constraints, ArrayRef<std::string> clobbers, Flags flags, Debug dbg)
+    : MemOp(Node_Assembly, world, type, inputs, dbg)
     , asm_template_(asm_template)
     , output_constraints_(output_constraints)
     , input_constraints_(input_constraints)

--- a/src/thorin/primop.h
+++ b/src/thorin/primop.h
@@ -150,7 +150,6 @@ private:
 public:
     const PrimType* type() const { return BinOp::type()->as<PrimType>(); }
     ArithOpTag arithop_tag() const { return (ArithOpTag) tag(); }
-    const char* op_name() const override;
 
     friend class World;
 };
@@ -165,7 +164,6 @@ private:
 public:
     const PrimType* type() const { return BinOp::type()->as<PrimType>(); }
     CmpTag cmp_tag() const { return (CmpTag) tag(); }
-    const char* op_name() const override;
 
     friend class World;
 };
@@ -182,7 +180,6 @@ private:
 public:
     const PrimType* type() const { return Def::type()->as<PrimType>(); }
     MathOpTag mathop_tag() const { return (MathOpTag) tag(); }
-    const char* op_name() const override;
 
     friend class World;
 };

--- a/src/thorin/rec_stream.cpp
+++ b/src/thorin/rec_stream.cpp
@@ -68,8 +68,6 @@ void RecStreamer::run() {
 void Def::dump() const { dump(0); }
 void Def::dump(size_t max) const { Stream s(std::cout); stream(s, max).endl(); }
 
-void Type::dump() const { Stream s(std::cout); stream(s).endl(); }
-
 Stream& Def::stream(Stream& s) const {
     if (isa<Param>() || isa<App>() || no_dep()) return stream1(s);
     return s << unique_name();

--- a/src/thorin/tables/nodetable.h
+++ b/src/thorin/tables/nodetable.h
@@ -47,6 +47,7 @@
     THORIN_NODE(Filter, filter)
     // Type
         // PrimType
+        THORIN_NODE(Star, star)
         THORIN_NODE(App, app)
         THORIN_NODE(DefiniteArrayType, definite_array_type)
         THORIN_NODE(FnType, fn)

--- a/src/thorin/transform/cleanup_world.cpp
+++ b/src/thorin/transform/cleanup_world.cpp
@@ -36,7 +36,7 @@ private:
 };
 
 void Cleaner::eliminate_tail_rec() {
-    Scope::for_each(*world_, [&](Scope& scope) {
+    Scope::for_each(world(), [&](Scope& scope) {
         auto entry = scope.entry();
 
         bool only_tail_calls = true;
@@ -233,7 +233,7 @@ next_continuation:;
 
 void Cleaner::rebuild() {
     auto fresh_world = std::make_unique<World>(world());
-    Importer importer(*world_, *fresh_world);
+    Importer importer(world(), *fresh_world);
     importer.def_old2new_.rehash(world_->defs().capacity());
 
     for (auto&& [_, cont] : world().externals()) {
@@ -267,7 +267,6 @@ void Cleaner::verify_closedness() {
 }
 
 void Cleaner::within(const Def* def) {
-    if (def->isa<Param>()) return; // TODO remove once Params are within World's sea of nodes
     assert(&def->type()->world() == &world());
     assert_unused(world().defs().contains(def));
 }

--- a/src/thorin/transform/cleanup_world.cpp
+++ b/src/thorin/transform/cleanup_world.cpp
@@ -46,7 +46,7 @@ void Cleaner::eliminate_tail_rec() {
                 if (use.index() == 0 && use->isa<App>()) {
                     recursive = true;
                     continue;
-                } else if (use->isa_nom<Param>())
+                } else if (use->isa<Param>())
                     continue; // ignore params
 
                 world().ELOG("non-recursive usage of {} index:{} use:{}", scope.entry()->name(), use.index(), use.def()->to_string());
@@ -202,7 +202,7 @@ void Cleaner::eliminate_params() {
 
             if (!proxy_idx.empty()) {
                 auto ncontinuation = world().continuation(
-                    world().fn_type(ocontinuation->type()->ops().cut(proxy_idx)),
+                    world().fn_type(ocontinuation->type()->types().cut(proxy_idx)),
                     ocontinuation->attributes(), ocontinuation->debug_history());
                 size_t j = 0;
                 for (auto i : param_idx) {
@@ -234,7 +234,6 @@ next_continuation:;
 void Cleaner::rebuild() {
     auto fresh_world = std::make_unique<World>(world());
     Importer importer(*world_, *fresh_world);
-    importer.type_old2new_.rehash(world_->types().capacity());
     importer.def_old2new_.rehash(world_->defs().capacity());
 
     for (auto&& [_, cont] : world().externals()) {
@@ -269,7 +268,7 @@ void Cleaner::verify_closedness() {
 
 void Cleaner::within(const Def* def) {
     if (def->isa<Param>()) return; // TODO remove once Params are within World's sea of nodes
-    assert(world().types().contains(def->type()));
+    assert(&def->type()->world() == &world());
     assert_unused(world().defs().contains(def));
 }
 

--- a/src/thorin/transform/cleanup_world.h
+++ b/src/thorin/transform/cleanup_world.h
@@ -5,7 +5,7 @@ namespace thorin {
 
 class World;
 
-void cleanup_world(World& world);
+void cleanup_world(std::unique_ptr<World>& world);
 
 }
 

--- a/src/thorin/transform/closure_conversion.cpp
+++ b/src/thorin/transform/closure_conversion.cpp
@@ -24,7 +24,7 @@ public:
                 continue;
             }
 
-            auto new_type = world_.fn_type(convert(continuation->type())->ops());
+            auto new_type = world_.fn_type(defs2types(convert_type(continuation->type())->ops()));
             if (new_type != continuation->type()) {
                 auto new_continuation = world_.continuation(new_type->as<FnType>(), continuation->debug());
                 if (continuation->is_intrinsic())
@@ -66,12 +66,15 @@ public:
         if (!callee || !callee->is_intrinsic()) {
             Array<const Def*> new_args(body->num_args());
             for (size_t i = 0, e = body->num_args(); i != e; ++i)
-                new_args[i] = convert(body->arg(i));
-            continuation->jump(convert(body->callee(), true), new_args, continuation->debug());
+                new_args[i] = convert_def(body->arg(i));
+            continuation->jump(convert_def(body->callee(), true), new_args, continuation->debug());
         }
     }
 
-    const Def* convert(const Def* def, bool as_callee = false) {
+    const Def* convert_def(const Def* def, bool as_callee = false) {
+        if (auto t = def->isa<Type>())
+            return convert_type(t);
+
         if (new_defs_.count(def)) def = new_defs_[def];
         if (def->order() <= 1)
             return def;
@@ -145,13 +148,13 @@ public:
             }
             wrapper->jump(lifted, wrapper_args);
 
-            auto closure_type = convert(continuation->type());
+            auto closure_type = convert_type(continuation->type());
             return world_.closure(closure_type->as<ClosureType>(), wrapper, thin_env ? free_vars[0] : world_.tuple(free_vars), continuation->debug());
         } else {
             // TODO need to consider Params?
             Array<const Def*> ops(def->ops());
-            for (auto& op : ops) op = convert(op);
-            return new_defs_[def] = def->rebuild(world_, convert(def->type()), ops);
+            for (auto& op : ops) op = convert_def(op);
+            return new_defs_[def] = def->rebuild(world_, convert_type(def->type()), ops);
         }
         THORIN_UNREACHABLE;
     }
@@ -160,10 +163,10 @@ public:
     // - fn (A, B, fn(C), fn(D)) => closure(fn (A, B, fn(convert(C)), closure(fn(convert(D)))))
     // - struct S { fn (X, fn(Y)) } => struct T { closure(fn (X, fn(Y))) }
     // - ...
-    const Type* convert(const Type* type) {
+    const Type* convert_type(const Type* type) {
         if (new_types_.count(type)) return new_types_[type];
         if (type->order() <= 1) return type;
-        Array<const Type*> ops(type->ops());
+        Array<const Def*> ops(type->ops());
 
         const Type* new_type = nullptr;
         if (type->isa<StructType>()) {
@@ -175,32 +178,32 @@ public:
         // accept one parameter of order 1 (the return continuation) for function types
         bool ret = !type->isa<FnType>();
         for (auto& op : ops) {
-            op = convert(op);
+            op = convert_def(op);
             if (!ret &&
                 op->isa<ClosureType>() &&
                 op->as<ClosureType>()->inner_order() == 1) {
                 ret = true;
-                op = world_.fn_type(op->ops());
+                op = world_.fn_type(defs2types(op->ops()));
             }
         }
 
         if (type->isa<StructType>()) {
-            auto struct_type = new_type->as<StructType>();
+            StructType* struct_type = const_cast<StructType*>(new_type->as<StructType>());
             for (size_t i = 0, e = ops.size(); i != e; ++i)
-                struct_type->set(i, ops[i]);
+                struct_type->set_op(i, ops[i]);
         } else {
-            new_type = type->rebuild(type->table(), ops);
+            new_type = type->rebuild(world_, type->type(), ops)->as<Type>();
         }
         if (new_type->order() <= 1)
             return new_types_[type] = new_type;
         else
-            return new_types_[type] = world_.closure_type(new_type->ops());
+            return new_types_[type] = world_.closure_type(defs2types(new_type->ops()));
     }
 
 private:
     World& world_;
     Def2Def new_defs_;
-    Type2Type new_types_;
+    DefMap<const Type*> new_types_;
 };
 
 

--- a/src/thorin/transform/flatten_tuples.cpp
+++ b/src/thorin/transform/flatten_tuples.cpp
@@ -166,7 +166,7 @@ static Continuation* unwrap_def(Def2Def& wrapped, Def2Def& unwrapped, const Def*
     return jump(old_cont, call_args);
 }
 
-static void flatten_tuples(World& world, size_t max_tuple_size) {
+static void flatten_tuples(Thorin& thorin, size_t max_tuple_size) {
     // flatten tuples passed as arguments to functions
     bool todo = true;
     Def2Def wrapped, unwrapped;
@@ -177,11 +177,11 @@ static void flatten_tuples(World& world, size_t max_tuple_size) {
 
         for (auto pair : unwrapped) unwrapped_codom.emplace(pair.second);
 
-        for (auto cont : world.copy_continuations()) {
+        for (auto cont : thorin.world().copy_continuations()) {
             // do not change the signature of intrinsic/external functions
             if (!cont->has_body() ||
                 cont->is_intrinsic() ||
-                world.is_external(cont) ||
+                thorin.world().is_external(cont) ||
                 is_passed_to_accelerator(cont))
                 continue;
 
@@ -196,7 +196,7 @@ static void flatten_tuples(World& world, size_t max_tuple_size) {
 
             todo = true;
 
-            world.DLOG("flattened {}", cont);
+            thorin.world().DLOG("flattened {}", cont);
         }
 
         // remove original versions of wrapped functions
@@ -218,12 +218,12 @@ static void flatten_tuples(World& world, size_t max_tuple_size) {
     for (auto unwrap_pair : unwrapped)
         inline_calls(unwrap_pair.second->as_nom<Continuation>());
 
-    world.cleanup();
-    debug_verify(world);
+    thorin.cleanup();
+    debug_verify(thorin.world());
 }
 
-void flatten_tuples(World& world) {
-    flatten_tuples(world, std::numeric_limits<size_t>::max());
+void flatten_tuples(Thorin& thorin) {
+    flatten_tuples(thorin, std::numeric_limits<size_t>::max());
 }
 
 }

--- a/src/thorin/transform/flatten_tuples.cpp
+++ b/src/thorin/transform/flatten_tuples.cpp
@@ -13,10 +13,10 @@ static Continuation* unwrap_def(Def2Def&, Def2Def&, const Def*, const FnType*, s
 // Computes the type of the wrapped function
 static const Type* wrapped_type(const FnType* fn_type, size_t max_tuple_size) {
     std::vector<const Type*> nops;
-    for (auto op : fn_type->ops()) {
+    for (auto op : fn_type->types()) {
         if (auto tuple_type = op->isa<TupleType>()) {
             if (tuple_type->num_ops() <= max_tuple_size) {
-                for (auto arg : tuple_type->ops())
+                for (auto arg : tuple_type->types())
                     nops.push_back(arg);
             } else
                 nops.push_back(op);
@@ -26,7 +26,7 @@ static const Type* wrapped_type(const FnType* fn_type, size_t max_tuple_size) {
             nops.push_back(op);
         }
     }
-    return fn_type->table().fn_type(nops);
+    return fn_type->world().fn_type(nops);
 }
 
 static Continuation* jump(Continuation* cont, Array<const Def*>& args) {

--- a/src/thorin/transform/flatten_tuples.h
+++ b/src/thorin/transform/flatten_tuples.h
@@ -2,6 +2,6 @@
 
 namespace thorin {
 
-void flatten_tuples(World& world);
+void flatten_tuples(Thorin& thorin);
 
 }

--- a/src/thorin/transform/hls_channels.cpp
+++ b/src/thorin/transform/hls_channels.cpp
@@ -145,14 +145,14 @@ bool dependency_resolver(Dependencies& dependencies, const size_t dependent_kern
 }
 
 /**
- * @param importer hls world
+ * @param thorin hls world
  * @param Top2Kernel annonating hls_top configuration
  * @param old_world to connect with runtime (host) world
  * @return corresponding hls_top parameter for hls_launch_kernel in another world (params before rewriting kernels)
  */
 
-DeviceParams hls_channels(Importer& importer, Top2Kernel& top2kernel, World& old_world) {
-    auto& world = importer.world();
+DeviceParams hls_channels(Thorin& thorin, Importer& importer, Top2Kernel& top2kernel, World& old_world) {
+    auto& world = thorin.world();
     std::vector<Def2Mode> kernels_ch_modes; // vector of channel->mode maps for kernels which use channel(s)
     std::vector<Continuation*> new_kernels;
     Def2Def kernel_new2old;
@@ -403,7 +403,7 @@ DeviceParams hls_channels(Importer& importer, Top2Kernel& top2kernel, World& old
     world.make_external(hls_top);
 
     debug_verify(world);
-    world.cleanup();
+    thorin.cleanup();
 
     return old_kernels_params;
 }

--- a/src/thorin/transform/hls_channels.cpp
+++ b/src/thorin/transform/hls_channels.cpp
@@ -166,8 +166,8 @@ DeviceParams hls_channels(Thorin& thorin, Importer& importer, Top2Kernel& top2ke
             extract_kernel_channels(schedule(scope), def2mode);
 
             Array<const Type*> new_param_types(def2mode.size() + old_kernel->num_params());
-            std::copy(old_kernel->type()->ops().begin(),
-                    old_kernel->type()->ops().end(),
+            std::copy(old_kernel->type()->types().begin(),
+                    old_kernel->type()->types().end(),
                     new_param_types.begin());
             size_t i = old_kernel->num_params();
             // This vector records pairs containing:
@@ -205,7 +205,7 @@ DeviceParams hls_channels(Thorin& thorin, Importer& importer, Top2Kernel& top2ke
                 if (auto cont = def->isa_nom<Continuation>()) {
                     // Copy the basic block by calling stub
                     // Or reuse the newly created kernel copy if def is the old kernel
-                    auto new_cont = def == old_kernel ? new_kernel : cont->stub();
+                    auto new_cont = def == old_kernel ? new_kernel : cont->mangle_stub();
                     rewriter.old2new[cont] = new_cont;
                     for (size_t i = 0; i < cont->num_params(); ++i)
                         rewriter.old2new[cont->param(i)] = new_cont->param(i);

--- a/src/thorin/transform/hls_channels.h
+++ b/src/thorin/transform/hls_channels.h
@@ -23,7 +23,7 @@ class World;
  * resolves all dependency requirements between kernel calls
  * provides hls_top parameters for hls runtime
  */
-DeviceParams hls_channels(Importer&, Top2Kernel&, World&);
+DeviceParams hls_channels(Thorin&, Importer&, Top2Kernel&, World&);
 void hls_annotate_top(World&, const Top2Kernel&, Cont2Config&);
 
 }

--- a/src/thorin/transform/hoist_enters.cpp
+++ b/src/thorin/transform/hoist_enters.cpp
@@ -57,9 +57,9 @@ static void hoist_enters(const Scope& scope) {
         entry_enter->out_mem()->replace_uses(entry_enter->mem());
 }
 
-void hoist_enters(World& world) {
-    Scope::for_each(world, [] (const Scope& scope) { hoist_enters(scope); });
-    world.cleanup();
+void hoist_enters(Thorin& thorin) {
+    Scope::for_each(thorin.world(), [] (const Scope& scope) { hoist_enters(scope); });
+    thorin.cleanup();
 }
 
 }

--- a/src/thorin/transform/hoist_enters.h
+++ b/src/thorin/transform/hoist_enters.h
@@ -5,7 +5,7 @@ namespace thorin {
 
 class World;
 
-void hoist_enters(World&);
+void hoist_enters(Thorin&);
 
 }
 

--- a/src/thorin/transform/importer.cpp
+++ b/src/thorin/transform/importer.cpp
@@ -4,13 +4,13 @@ namespace thorin {
 
 const Type* Importer::import(const Type* otype) {
     if (auto ntype = type_old2new_.lookup(otype)) {
-        assert(&(*ntype)->table() == &world_);
+        assert(&(*ntype)->table() == &world());
         return *ntype;
     }
     size_t size = otype->num_ops();
 
     if (auto nominal_type = otype->isa<NominalType>()) {
-        auto ntype = nominal_type->stub(world_);
+        auto ntype = nominal_type->stub(world());
         type_old2new_[otype] = ntype;
         for (size_t i = 0; i != size; ++i)
             ntype->set(i, import(otype->op(i)));
@@ -21,16 +21,16 @@ const Type* Importer::import(const Type* otype) {
     for (size_t i = 0; i != size; ++i)
         nops[i] = import(otype->op(i));
 
-    auto ntype = otype->rebuild(world_, nops);
+    auto ntype = otype->rebuild(world(), nops);
     type_old2new_[otype] = ntype;
-    assert(&ntype->table() == &world_);
+    assert(&ntype->table() == &world());
 
     return ntype;
 }
 
 const Def* Importer::import(const Def* odef) {
     if (auto ndef = def_old2new_.lookup(odef)) {
-        assert(&(*ndef)->world() == &world_);
+        assert(&(*ndef)->world() == &world());
         return *ndef;
     }
 
@@ -39,7 +39,7 @@ const Def* Importer::import(const Def* odef) {
     if (auto oparam = odef->isa<Param>()) {
         import(oparam->continuation())->as_nom<Continuation>();
         auto nparam = def_old2new_[oparam];
-        assert(nparam && &nparam->world() == &world_);
+        assert(nparam && &nparam->world() == &world());
         return nparam;
     }
 

--- a/src/thorin/transform/importer.cpp
+++ b/src/thorin/transform/importer.cpp
@@ -2,32 +2,6 @@
 
 namespace thorin {
 
-/*const Type* Importer::import(const Type* otype) {
-    if (auto ntype = type_old2new_.lookup(otype)) {
-        assert(&(*ntype)->table() == &world());
-        return *ntype;
-    }
-    size_t size = otype->num_ops();
-
-    if (auto nominal_type = otype->isa<NominalType>()) {
-        auto ntype = nominal_type->stub(world());
-        type_old2new_[otype] = ntype;
-        for (size_t i = 0; i != size; ++i)
-            ntype->set(i, import(otype->op(i)));
-        return ntype;
-    }
-
-    Array<const Type*> nops(size);
-    for (size_t i = 0; i != size; ++i)
-        nops[i] = import(otype->op(i));
-
-    auto ntype = otype->rebuild(world(), nops);
-    type_old2new_[otype] = ntype;
-    assert(&ntype->table() == &world());
-
-    return ntype;
-}*/
-
 const Def* Importer::import(const Def* odef) {
     if (auto ndef = def_old2new_.lookup(odef)) {
         assert(&(*ndef)->world() == &world());
@@ -40,44 +14,6 @@ const Def* Importer::import(const Def* odef) {
     }
 
     auto ntype = import(odef->type())->as<Type>();
-
-    /*if (auto oparam = odef->isa<Param>()) {
-        import(oparam->continuation())->as_nom<Continuation>();
-        auto nparam = def_old2new_[oparam];
-        assert(nparam && &nparam->world() == &world());
-        return nparam;
-    }
-
-    if (auto ofilter = odef->isa<Filter>()) {
-        Array<const Def*> new_conditions(ofilter->num_ops());
-        for (size_t i = 0, e = ofilter->size(); i != e; ++i)
-            new_conditions[i] = import(ofilter->condition(i));
-        auto nfilter = world().filter(new_conditions, ofilter->debug());
-        return nfilter;
-    }
-
-    Continuation* ncontinuation = nullptr;
-    if (auto ocontinuation = odef->isa_nom<Continuation>()) { // create stub in new world
-        assert(!ocontinuation->dead_);
-        // TODO maybe we want to deal with intrinsics in a more streamlined way
-        if (ocontinuation == ocontinuation->world().branch())
-            return def_old2new_[ocontinuation] = world().branch();
-        if (ocontinuation == ocontinuation->world().end_scope())
-            return def_old2new_[ocontinuation] = world().end_scope();
-        auto npi = import(ocontinuation->type())->as<FnType>();
-        ncontinuation = world().continuation(npi, ocontinuation->attributes(), ocontinuation->debug_history());
-        assert(&ncontinuation->world() == &world());
-        assert(&npi->world() == &world());
-        for (size_t i = 0, e = ocontinuation->num_params(); i != e; ++i) {
-            ncontinuation->param(i)->set_name(ocontinuation->param(i)->debug_history().name);
-            def_old2new_[ocontinuation->param(i)] = ncontinuation->param(i);
-        }
-
-        def_old2new_[ocontinuation] = ncontinuation;
-
-        if (ocontinuation->is_external())
-            world().make_external(ncontinuation);
-    }*/
 
     Def* stub = nullptr;
     if (odef->isa_nom()) {
@@ -102,14 +38,6 @@ const Def* Importer::import(const Def* odef) {
         stub->rebuild_from(odef, nops);
         return stub;
     }
-
-    /*assert(ncontinuation && &ncontinuation->world() == &world());
-    auto napp = nops[0]->isa<App>();
-    if (napp)
-        ncontinuation->set_body(napp);
-    ncontinuation->set_filter(nops[1]->as<Filter>());
-    ncontinuation->verify();
-    return ncontinuation;*/
 }
 
 }

--- a/src/thorin/transform/importer.h
+++ b/src/thorin/transform/importer.h
@@ -21,12 +21,11 @@ public:
     }
 
     World& world() { return dst; }
-    const Type* import(const Type*);
+    //const Type* import(const Type*);
     const Def* import(const Def*);
     bool todo() const { return todo_; }
 
 public:
-    Type2Type type_old2new_;
     Def2Def def_old2new_;
     World& src;
     World& dst;

--- a/src/thorin/transform/importer.h
+++ b/src/thorin/transform/importer.h
@@ -8,18 +8,19 @@ namespace thorin {
 
 class Importer {
 public:
-    Importer(World& src)
-        : world_(src)
+    explicit Importer(World& src, World& dst)
+        : src(src)
+        , dst(dst)
     {
         if (src.is_pe_done())
-            world_.mark_pe_done();
+            world().mark_pe_done();
 #if THORIN_ENABLE_CHECKS
         if (src.track_history())
-            world_.enable_history(true);
+            world().enable_history(true);
 #endif
     }
 
-    World& world() { return world_; }
+    World& world() { return dst; }
     const Type* import(const Type*);
     const Def* import(const Def*);
     bool todo() const { return todo_; }
@@ -27,7 +28,8 @@ public:
 public:
     Type2Type type_old2new_;
     Def2Def def_old2new_;
-    World world_;
+    World& src;
+    World& dst;
     bool todo_ = false;
 };
 

--- a/src/thorin/transform/importer.h
+++ b/src/thorin/transform/importer.h
@@ -21,7 +21,6 @@ public:
     }
 
     World& world() { return dst; }
-    //const Type* import(const Type*);
     const Def* import(const Def*);
     bool todo() const { return todo_; }
 

--- a/src/thorin/transform/inliner.cpp
+++ b/src/thorin/transform/inliner.cpp
@@ -36,7 +36,8 @@ void force_inline(Scope& scope, int threshold) {
     }
 }
 
-void inliner(World& world) {
+void inliner(Thorin& thorin) {
+    World& world = thorin.world();
     world.VLOG("start inliner");
 
     static const int factor = 4;
@@ -95,7 +96,7 @@ void inliner(World& world) {
 
     world.VLOG("stop inliner");
     debug_verify(world);
-    world.cleanup();
+    thorin.cleanup();
 
 }
 

--- a/src/thorin/transform/inliner.h
+++ b/src/thorin/transform/inliner.h
@@ -11,7 +11,7 @@ class World;
  * If there still remain functions to be inlined, warnings will be emitted
  */
 void force_inline(Scope& scope, int threshold);
-void inliner(World& world);
+void inliner(Thorin&);
 
 }
 

--- a/src/thorin/transform/lift_builtins.cpp
+++ b/src/thorin/transform/lift_builtins.cpp
@@ -63,8 +63,9 @@ void lift_pipeline(World& world) {
 
 }
 
-void lift_builtins(World& world) {
+void lift_builtins(Thorin& thorin) {
     // This must be run first
+    World& world = thorin.world();
     lift_pipeline(world);
 
     while (true) {
@@ -125,7 +126,7 @@ void lift_builtins(World& world) {
             }
         }
 
-        world.cleanup();
+        thorin.cleanup();
     }
 }
 

--- a/src/thorin/transform/lift_builtins.cpp
+++ b/src/thorin/transform/lift_builtins.cpp
@@ -65,10 +65,10 @@ void lift_pipeline(World& world) {
 
 void lift_builtins(Thorin& thorin) {
     // This must be run first
-    World& world = thorin.world();
-    lift_pipeline(world);
+    lift_pipeline(thorin.world());
 
     while (true) {
+        World& world = thorin.world();
         Continuation* cur = nullptr;
         Scope::for_each(world, [&] (const Scope& scope) {
             if (cur) return;

--- a/src/thorin/transform/lift_builtins.h
+++ b/src/thorin/transform/lift_builtins.h
@@ -5,7 +5,7 @@ namespace thorin {
 
 class World;
 
-void lift_builtins(World&);
+void lift_builtins(Thorin&);
 
 }
 

--- a/src/thorin/transform/mangle.cpp
+++ b/src/thorin/transform/mangle.cpp
@@ -10,7 +10,7 @@ namespace thorin {
 const Def* Rewriter::instantiate(const Def* odef) {
     if (auto ndef = old2new.lookup(odef)) return *ndef;
 
-    if (odef->isa_structural()) {
+    if (odef->isa_structural() && !odef->isa<Param>()) {
         Array<const Def*> nops(odef->num_ops());
         for (size_t i = 0; i != odef->num_ops(); ++i)
             nops[i] = instantiate(odef->op(i));
@@ -168,6 +168,7 @@ const Def* Mangler::mangle(const Def* old_def) {
             nops[i] = mangle(old_def->op(i));
 
         auto type = old_def->type(); // TODO reduce
+        assert(!old_def->isa<Type>());
         return def2def_[old_def] = old_def->rebuild(world(), type, nops);
     }
 }

--- a/src/thorin/transform/mangle.cpp
+++ b/src/thorin/transform/mangle.cpp
@@ -107,7 +107,7 @@ Continuation* Mangler::mangle() {
 Continuation* Mangler::mangle_head(Continuation* old_continuation) {
     assert(!def2def_.contains(old_continuation));
     assert(old_continuation->has_body());
-    Continuation* new_continuation = old_continuation->stub();
+    Continuation* new_continuation = old_continuation->mangle_stub();
     def2def_[old_continuation] = new_continuation;
 
     for (size_t i = 0, e = old_continuation->num_params(); i != e; ++i)

--- a/src/thorin/transform/mangle.h
+++ b/src/thorin/transform/mangle.h
@@ -30,7 +30,6 @@ private:
     const Scope& scope_;
     Defs args_;
     Defs lift_;
-    Type2Type type2type_;
     Continuation* old_entry_;
     Continuation* new_entry_;
     DefSet defs_;

--- a/src/thorin/transform/partial_evaluation.cpp
+++ b/src/thorin/transform/partial_evaluation.cpp
@@ -57,7 +57,7 @@ public:
         if (auto ndef = old2new_.lookup(odef))
             return *ndef;
 
-        if (odef->isa_structural()) {
+        if (odef->isa_structural() && !odef->isa<Param>()) {
             Array<const Def*> nops(odef->num_ops());
             for (size_t i = 0; i != odef->num_ops(); ++i)
                 nops[i] = instantiate(odef->op(i));

--- a/src/thorin/transform/split_slots.cpp
+++ b/src/thorin/transform/split_slots.cpp
@@ -86,12 +86,12 @@ static bool split_slots(const Scope& scope) {
     return todo;
 }
 
-void split_slots(World& world) {
+void split_slots(Thorin& thorin) {
     bool todo = true;
     while (todo) {
         todo = false;
-        Scope::for_each(world, [&] (const Scope& scope) { todo |= split_slots(scope); });
-        world.cleanup();
+        Scope::for_each(thorin.world(), [&] (const Scope& scope) { todo |= split_slots(scope); });
+        thorin.cleanup();
     }
 }
 

--- a/src/thorin/transform/split_slots.h
+++ b/src/thorin/transform/split_slots.h
@@ -8,7 +8,7 @@ class World;
 /**
  * Tries to split @p Slot%s that are accessed through constant @p LEA%s.
  */
-void split_slots(World&);
+void split_slots(Thorin&);
 
 }
 

--- a/src/thorin/type.cpp
+++ b/src/thorin/type.cpp
@@ -11,8 +11,18 @@
 
 namespace thorin {
 
-Type::Type(World& w, NodeTag tag, Defs args, Debug dbg) : Type(w, tag, w.star(), args, dbg) {}
+Type::Type(World& w, NodeTag tag, Defs args, Debug dbg) : Type(w, tag, w.star(), args, dbg) {
+    // The overridden version of set_op is ignored in the Def ctor, because according to the C++ spec, virtuals are disabled in ctors (!)
+    // So this is not actually duplicate code - for the nominal types Type::set_op will do what we want.
+    for (auto& def : args)
+        order_ = std::max(order_, def->order());
+}
 Type::Type(World& w, NodeTag tag, size_t size, Debug dbg) : Type(w, tag, w.star(), size, dbg) {}
+
+void Type::set_op(size_t i, const Def* def) {
+    Def::set_op(i, def);
+    order_ = std::max(order_, def->order());
+}
 
 Array<const Def*> types2defs(ArrayRef<const Type*> types) {
     Array<const Def*> defs(types.size());

--- a/src/thorin/type.cpp
+++ b/src/thorin/type.cpp
@@ -130,62 +130,6 @@ bool PtrType::equal(const Def* other) const {
     return ptr->device() == device() && ptr->addr_space() == addr_space();
 }
 
-//------------------------------------------------------------------------------
-
-/*
- * stream
- */
-
-Stream& Type::stream(Stream& s) const {
-    if (false) {}
-    else if (isa<BottomType>()) return s.fmt("!!");
-    else if (isa<   MemType>()) return s.fmt("mem");
-    else if (isa< FrameType>()) return s.fmt("frame");
-    else if (auto t = isa<DefiniteArrayType>()) {
-        return s.fmt("[{} x {}]", t->dim(), t->elem_type());
-    } else if (auto t = isa<FnType>()) {
-        return s.fmt("fn[{, }]", t->ops());
-    } else if (auto t = isa<ClosureType>()) {
-        return s.fmt("closure [{, }]", t->ops());
-    } else if (auto t = isa<IndefiniteArrayType>()) {
-        return s.fmt("[{}]", t->elem_type());
-    } else if (auto t = isa<StructType>()) {
-        return s.fmt("struct {}", t->name());
-    } else if (auto t = isa<VariantType>()) {
-        return s.fmt("variant {}", t->name());
-    } else if (auto t = isa<TupleType>()) {
-        return s.fmt("[{, }]", t->ops());
-    } else if (auto t = isa<PtrType>()) {
-        if (t->is_vector()) s.fmt("<{} x", t->length());
-        s.fmt("{}*", t->pointee());
-        if (t->is_vector()) s.fmt(">");
-        if (t->device() != -1) s.fmt("[{}]", t->device());
-
-        switch (t->addr_space()) {
-            case AddrSpace::Global:   s.fmt("[Global]");   break;
-            case AddrSpace::Texture:  s.fmt("[Tex]");      break;
-            case AddrSpace::Shared:   s.fmt("[Shared]");   break;
-            case AddrSpace::Constant: s.fmt("[Constant]"); break;
-            default: /* ignore unknown address space */    break;
-        }
-        return s;
-    } else if (auto t = isa<PrimType>()) {
-        if (t->is_vector()) s.fmt("<{} x", t->length());
-
-        switch (t->primtype_tag()) {
-#define THORIN_ALL_TYPE(T, M) case Node_PrimType_##T: s.fmt(#T); break;
-#include "thorin/tables/primtypetable.h"
-            default: THORIN_UNREACHABLE;
-        }
-
-        if (t->is_vector()) s.fmt(">");
-        return s;
-    }
-    THORIN_UNREACHABLE;
-}
-
-//------------------------------------------------------------------------------
-
 TypeTable::TypeTable(World& world)
     : world_(world)
     , star_     (world.put<Star>((world)))

--- a/src/thorin/type.cpp
+++ b/src/thorin/type.cpp
@@ -11,15 +11,23 @@
 
 namespace thorin {
 
-Type::Type(TypeTable& table, int tag, Types ops)
-    : table_(&table)
-    , tag_(tag)
-    , ops_(ops.size())
-{
-    for (size_t i = 0, e = num_ops(); i != e; ++i) {
-        if (auto op = ops[i])
-            set(i, op);
-    }
+Type::Type(World& w, NodeTag tag, Defs args, Debug dbg) : Type(w, tag, w.star(), args, dbg) {}
+Type::Type(World& w, NodeTag tag, size_t size, Debug dbg) : Type(w, tag, w.star(), size, dbg) {}
+
+Array<const Def*> types2defs(ArrayRef<const Type*> types) {
+    Array<const Def*> defs(types.size());
+    size_t i = 0;
+    for (auto type : types)
+        defs[i++] = type->as<Def>();
+    return defs;
+}
+
+Array<const Type*> defs2types(ArrayRef<const Def*> defs) {
+    Array<const Type*> types(defs.size());
+    size_t i = 0;
+    for (auto type : defs)
+        types[i++] = type->as<Type>();
+    return types;
 }
 
 //------------------------------------------------------------------------------
@@ -28,34 +36,33 @@ Type::Type(TypeTable& table, int tag, Types ops)
  * rebuild
  */
 
-const Type* NominalType::rebuild(TypeTable&, Types) const {
+const Type* NominalType::rebuild(World& w, const Type* t, Defs o) const {
     THORIN_UNREACHABLE;
-    return this;
 }
 
-const Type* BottomType         ::rebuild(TypeTable& t, Types  ) const { return t.bottom_type(); }
-const Type* ClosureType        ::rebuild(TypeTable& t, Types o) const { return t.closure_type(o); }
-const Type* DefiniteArrayType  ::rebuild(TypeTable& t, Types o) const { return t.definite_array_type(o[0], dim()); }
-const Type* FnType             ::rebuild(TypeTable& t, Types o) const { return t.fn_type(o); }
-const Type* FrameType          ::rebuild(TypeTable& t, Types  ) const { return t.frame_type(); }
-const Type* IndefiniteArrayType::rebuild(TypeTable& t, Types o) const { return t.indefinite_array_type(o[0]); }
-const Type* MemType            ::rebuild(TypeTable& t, Types  ) const { return t.mem_type(); }
-const Type* PrimType           ::rebuild(TypeTable& t, Types  ) const { return t.prim_type(primtype_tag(), length()); }
-const Type* PtrType            ::rebuild(TypeTable& t, Types o) const { return t.ptr_type(o.front(), length(), device(), addr_space()); }
-const Type* TupleType          ::rebuild(TypeTable& t, Types o) const { return t.tuple_type(o); }
+const Type* BottomType         ::rebuild(World& w, const Type* t, Defs o) const { return w.bottom_type(); }
+const Type* ClosureType        ::rebuild(World& w, const Type* t, Defs o) const { return w.closure_type(defs2types(o)); }
+const Type* DefiniteArrayType  ::rebuild(World& w, const Type* t, Defs o) const { return w.definite_array_type(o[0]->as<Type>(), dim()); }
+const Type* FnType             ::rebuild(World& w, const Type* t, Defs o) const { return w.fn_type(defs2types(o)); }
+const Type* FrameType          ::rebuild(World& w, const Type* t, Defs o) const { return w.frame_type(); }
+const Type* IndefiniteArrayType::rebuild(World& w, const Type* t, Defs o) const { return w.indefinite_array_type(o[0]->as<Type>()); }
+const Type* MemType            ::rebuild(World& w, const Type* t, Defs o) const { return w.mem_type(); }
+const Type* PrimType           ::rebuild(World& w, const Type* t, Defs o) const { return w.prim_type(primtype_tag(), length()); }
+const Type* PtrType            ::rebuild(World& w, const Type* t, Defs o) const { return w.ptr_type(o[0]->as<Type>(), length(), device(), addr_space()); }
+const Type* TupleType          ::rebuild(World& w, const Type* t, Defs o) const { return w.tuple_type(defs2types(o)); }
 
 /*
  * stub
  */
 
-const NominalType* StructType::stub(TypeTable& to) const {
-    auto type = to.struct_type(name(), num_ops());
+StructType* StructType::stub(World& world, const Type*) const {
+    auto type = world.struct_type(name(), num_ops());
     std::copy(op_names_.begin(), op_names_.end(), type->op_names().begin());
     return type;
 }
 
-const NominalType* VariantType::stub(TypeTable& to) const {
-    auto type = to.variant_type(name(), num_ops());
+VariantType* VariantType::stub(World& world, const Type*) const {
+    auto type = world.variant_type(name(), num_ops());
     std::copy(op_names_.begin(), op_names_.end(), type->op_names().begin());
     return type;
 }
@@ -64,8 +71,8 @@ const NominalType* VariantType::stub(TypeTable& to) const {
 
 const VectorType* VectorType::scalarize() const {
     if (auto ptr = isa<PtrType>())
-        return table().ptr_type(ptr->pointee());
-    return table().prim_type(as<PrimType>()->primtype_tag());
+        return world().ptr_type(ptr->pointee());
+    return world().prim_type(as<PrimType>()->primtype_tag());
 }
 
 bool FnType::is_returning() const {
@@ -85,7 +92,7 @@ bool FnType::is_returning() const {
 }
 
 bool VariantType::has_payload() const {
-    return !std::all_of(ops().begin(), ops().end(), is_type_unit);
+    return !std::all_of(types().begin(), types().end(), is_type_unit);
 }
 
 bool use_lea(const Type* type) { return type->isa<StructType>() || type->isa<ArrayType>(); }
@@ -95,15 +102,6 @@ bool use_lea(const Type* type) { return type->isa<StructType>() || type->isa<Arr
 /*
  * hash
  */
-
-hash_t Type::vhash() const {
-    if (is_nominal())
-        return thorin::murmur3(hash_t(tag()) << hash_t(32-8) | hash_t(gid()));
-    hash_t seed = thorin::hash_begin(uint8_t(tag()));
-    for (auto op : ops_)
-        seed = thorin::hash_combine(seed, uint32_t(op->gid()));
-    return seed;
-}
 
 hash_t PtrType::vhash() const {
     return hash_combine(VectorType::vhash(), (hash_t)device(), (hash_t)addr_space());
@@ -115,15 +113,7 @@ hash_t PtrType::vhash() const {
  * equal
  */
 
-bool Type::equal(const Type* other) const {
-    if (is_nominal())
-        return this == other;
-    if (tag() == other->tag() && num_ops() == other->num_ops())
-        return std::equal(ops().begin(), ops().end(), other->ops().begin());
-    return false;
-}
-
-bool PtrType::equal(const Type* other) const {
+bool PtrType::equal(const Def* other) const {
     if (!VectorType::equal(other))
         return false;
     auto ptr = other->as<PtrType>();
@@ -186,62 +176,46 @@ Stream& Type::stream(Stream& s) const {
 
 //------------------------------------------------------------------------------
 
-TypeTable::TypeTable()
-    : unit_     (insert<TupleType >(*this, Types()))
-    , fn0_      (insert<FnType    >(*this, Types()))
-    , bottom_ty_(insert<BottomType>(*this))
-    , mem_      (insert<MemType   >(*this))
-    , frame_    (insert<FrameType >(*this))
+TypeTable::TypeTable(World& world)
+    : world_(world)
+    , star_     (world.put<Star>((world)))
+    , unit_     (world.put<TupleType>(world, Defs(), Debug()))
+    , fn0_      (world.put<FnType    >(world, Defs(), Node_FnType, Debug()))
+    , bottom_ty_(world.put<BottomType>(world, Debug()))
+    , mem_      (world.put<MemType   >(world, Debug()))
+    , frame_    (world.put<FrameType >(world, Debug()))
 {
 #define THORIN_ALL_TYPE(T, M) \
-    primtypes_[PrimType_##T - Begin_PrimType] = insert<PrimType>(*this, PrimType_##T, 1);
+    primtypes_[PrimType_##T - Begin_PrimType] = world.make<PrimType>(world, PrimType_##T, 1, Debug());
 #include "thorin/tables/primtypetable.h"
 }
 
-const Type* TypeTable::tuple_type(Types ops) {
-    return ops.size() == 1 ? ops.front() : insert<TupleType>(*this, ops);
+const Type* World::tuple_type(Types ops) {
+    return ops.size() == 1 ? ops.front()->as<Type>() : make<TupleType>(*this, types2defs(ops), Debug());
 }
 
-const StructType* TypeTable::struct_type(Symbol name, size_t size) {
-    auto type = new StructType(*this, name, size, types_.size());
-    const auto& p = types_.insert(type);
-    assert_unused(p.second && "hash/equal broken");
-    return type;
+StructType* World::struct_type(Symbol name, size_t size) {
+    return put<StructType>(*this, name, size, Debug());
 }
 
-const VariantType* TypeTable::variant_type(Symbol name, size_t size) {
-    auto type = new VariantType(*this, name, size, types_.size());
-    const auto& p = types_.insert(type);
-    assert_unused(p.second && "hash/equal broken");
-    return type;
+VariantType* World::variant_type(Symbol name, size_t size) {
+    return put<VariantType>(*this, name, size, Debug());
 }
 
-const PrimType* TypeTable::prim_type(PrimTypeTag tag, size_t length) {
+const PrimType* World::prim_type(PrimTypeTag tag, size_t length) {
     size_t i = tag - Begin_PrimType;
     assert(i < (size_t) Num_PrimTypes);
-    return length == 1 ? primtypes_[i] : insert<PrimType>(*this, tag, length);
+    return length == 1 ? types_.primtypes_[i] : make<PrimType>(*this, tag, length, Debug());
 }
 
-const PtrType* TypeTable::ptr_type(const Type* pointee, size_t length, int32_t device, AddrSpace addr_space) {
-    return insert<PtrType>(*this, pointee, length, device, addr_space);
+const PtrType* World::ptr_type(const Type* pointee, size_t length, int32_t device, AddrSpace addr_space) {
+    return make<PtrType>(*this, pointee, length, device, addr_space, Debug());
 }
 
-const FnType*              TypeTable::fn_type(Types args) { return insert<FnType>(*this, args); }
-const ClosureType*         TypeTable::closure_type(Types args) { return insert<ClosureType>(*this, args); }
-const DefiniteArrayType*   TypeTable::definite_array_type(const Type* elem, u64 dim) { return insert<DefiniteArrayType>(*this, elem, dim); }
-const IndefiniteArrayType* TypeTable::indefinite_array_type(const Type* elem) { return insert<IndefiniteArrayType>(*this, elem); }
-
-template <typename T, typename... Args>
-const T* TypeTable::insert(Args&&... args) {
-    T t(std::forward<Args&&>(args)...);
-    auto it = types_.find(&t);
-    if (it != types_.end())
-        return (*it)->template as<T>();
-    auto new_t = new T(std::move(t));
-    new_t->gid_ = types_.size();
-    types_.emplace(new_t);
-    return new_t;
-}
+const FnType*              World::fn_type(Types args) { return make<FnType>(*this, types2defs(args), Node_FnType, Debug()); }
+const ClosureType*         World::closure_type(Types args) { return make<ClosureType>(*this, types2defs(args), Debug()); }
+const DefiniteArrayType*   World::definite_array_type(const Type* elem, u64 dim) { return make<DefiniteArrayType>(*this, elem, dim, Debug()); }
+const IndefiniteArrayType* World::indefinite_array_type(const Type* elem) { return make<IndefiniteArrayType>(*this, elem, Debug()); }
 
 //------------------------------------------------------------------------------
 

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -1,6 +1,7 @@
 #ifndef THORIN_TYPE_H
 #define THORIN_TYPE_H
 
+#include "thorin/def.h"
 #include "thorin/enums.h"
 #include "thorin/util/hash.h"
 #include "thorin/util/cast.h"
@@ -15,174 +16,168 @@ class Type;
 using Types = ArrayRef<const Type*>;
 
 /// Base class for all \p Type%s.
-class Type : public RuntimeCast<Type>, public Streamable<Type> {
+class Type : public Def, public Streamable<Type> {
 protected:
-    Type(TypeTable& table, int tag, Types ops);
-
-    void set(size_t i, const Type* type) {
-        ops_[i] = type;
-        order_ = std::max(order_, type->order());
-    }
+    /// Constructor for a @em structural Type.
+    Type(World& w, NodeTag tag, const Type* type, Defs args, Debug dbg) : Def(w, tag, type, args, dbg) {}
+    Type(World& w, NodeTag tag, Defs args, Debug dbg);
+    /// Constructor for a @em nom Type.
+    Type(World& w, NodeTag tag, const Type* type, size_t size, Debug dbg) : Def(w, tag, type, size, dbg) {}
+    Type(World& w, NodeTag tag, size_t size, Debug dbg);
 
 public:
-    int tag() const { return tag_; }
-    TypeTable& table() const { return *table_; }
-
-    Types ops() const { return ops_; }
-    const Type* op(size_t i) const { return ops()[i]; }
-    size_t num_ops() const { return ops_.size(); }
-    bool empty() const { return ops_.empty(); }
-
-    bool is_nominal() const { return nominal_; } ///< A nominal @p Type is always different from each other @p Type.
-    int order() const { return order_; }
-    size_t gid() const { return gid_; }
-    hash_t hash() const { return hash_ == 0 ? hash_ = vhash() : hash_; }
-    virtual bool equal(const Type*) const;
-    virtual const Type* rebuild(TypeTable&, Types) const = 0;
+    int order() const override { return order_; }
     Stream& stream(Stream&) const;
-    void dump() const;
 
+    std::vector<const Type*> filter_type_ops() const {
+        std::vector<const Type*> type_ops;
+        for (auto& op : ops()) {
+            if (auto t = op->isa<Type>())
+                type_ops.push_back(t);
+        }
+        return type_ops;
+    }
 protected:
-    virtual hash_t vhash() const;
-
-    mutable hash_t hash_ = 0;
-    mutable bool nominal_  = false;
     int order_ = 0;
-    size_t gid_;
+    friend class World;
+};
 
-private:
-    mutable TypeTable* table_;
+class Star : public Type {
+protected:
+    explicit Star(World& w) : Type(w, Node_Star, nullptr, 0, {}) {
+        set_type(this);
+    }
 
-    int tag_;
-    thorin::Array<const Type*> ops_;
+    friend class World;
+};
 
-    friend TypeTable;
+Array<const Def*> types2defs(ArrayRef<const Type*> types);
+Array<const Type*> defs2types(ArrayRef<const Def*> types);
+
+template<class T>
+class TypeOpsMixin {
+public:
+    Types types() const {
+        Defs defs = static_cast<const T*>(this)->ops();
+        const Def* const* ptr = defs.begin();
+        auto ptr2 = reinterpret_cast<const Type* const*>(ptr);
+        auto types = Types(ptr2, defs.size());
+        return types;
+    }
 };
 
 /// Type of a tuple (structurally typed).
-class TupleType : public Type {
+class TupleType : public Type, public TypeOpsMixin<TupleType> {
 private:
-    TupleType(TypeTable& table, Types ops)
-        : Type(table, Node_TupleType, ops)
+    TupleType(World& world, Defs ops, Debug dbg)
+        : Type(world, Node_TupleType, ops, dbg)
     {}
 
 public:
-    const Type* rebuild(TypeTable&, Types) const override;
-
-    friend class TypeTable;
+    const Type* rebuild(World&, const Type*, Defs) const override;
+    friend class World;
 };
 
 /// Base class for nominal types (types that have
 /// a name that uniquely identifies them).
 class NominalType : public Type {
 protected:
-    NominalType(TypeTable& table, int tag, Symbol name, size_t size, size_t gid)
-        : Type(table, tag, thorin::Array<const Type*>(size))
+    NominalType(World& world, NodeTag tag, Symbol name, size_t size, Debug dbg)
+        : Type(world, tag, size, dbg)
         , name_(name)
         , op_names_(size)
-    {
-        nominal_ = true;
-        gid_ = gid;
-    }
+    {}
 
     Symbol name_;
     Array<Symbol> op_names_;
 
 private:
-    const Type* rebuild(TypeTable&, Types) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
 public:
     Symbol name() const { return name_; }
     Symbol op_name(size_t i) const { return op_names_[i]; }
-    void set(size_t i, const Type* type) const {
-        return const_cast<NominalType*>(this)->Type::set(i, type);
-    }
     void set_op_name(size_t i, Symbol name) const {
         const_cast<NominalType*>(this)->op_names_[i] = name;
     }
     Array<Symbol>& op_names() const {
         return const_cast<NominalType*>(this)->op_names_;
     }
-
-    /// Recreates a fresh new nominal type of the
-    /// same kind with the same number of operands,
-    /// initially all unset.
-    virtual const NominalType* stub(TypeTable&) const = 0;
 };
 
-class StructType : public NominalType {
+class StructType : public NominalType, public TypeOpsMixin<TupleType> {
 private:
-    StructType(TypeTable& table, Symbol name, size_t size, size_t gid)
-        : NominalType(table, Node_StructType, name, size, gid)
+    StructType(World& world, Symbol name, size_t size, Debug dbg)
+        : NominalType(world, Node_StructType, name, size, dbg)
     {}
 
 public:
-    const NominalType* stub(TypeTable&) const override;
+    virtual StructType* stub(World&, const Type*) const override;
 
-    friend class TypeTable;
+    friend class World;
 };
 
-class VariantType : public NominalType {
+class VariantType : public NominalType, public TypeOpsMixin<TupleType> {
 private:
-    VariantType(TypeTable& table, Symbol name, size_t size, size_t gid)
-        : NominalType(table, Node_VariantType, name, size, gid)
+    VariantType(World& world, Symbol name, size_t size, Debug dbg)
+        : NominalType(world, Node_VariantType, name, size, dbg)
     {}
 
 public:
-    const NominalType* stub(TypeTable&) const override;
+    virtual VariantType* stub(World&, const Type*) const override;
 
     bool has_payload() const;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 /// The type of the memory monad.
 class MemType : public Type {
 private:
-    MemType(TypeTable& table)
-        : Type(table, Node_MemType, {})
+    MemType(World& world, Debug dbg)
+        : Type(world, Node_MemType, Defs(), dbg)
     {}
 
-    const Type* rebuild(TypeTable&, Types) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 /// The type of App nodes.
 class BottomType : public Type {
 private:
-    BottomType(TypeTable& table)
-            : Type(table, Node_BotType, {})
+    BottomType(World& world, Debug dbg)
+        : Type(world, Node_BotType, Defs(), dbg)
     {}
 
-    const Type* rebuild(TypeTable& to, Types ops) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 /// The type of a stack frame.
 class FrameType : public Type {
 private:
-    FrameType(TypeTable& table)
-        : Type(table, Node_FrameType, {})
+    FrameType(World& world, Debug dbg)
+        : Type(world, Node_FrameType, Defs(), dbg)
     {}
 
-    const Type* rebuild(TypeTable&, Types) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 /// Base class for all SIMD types.
 class VectorType : public Type {
 protected:
-    VectorType(TypeTable& table, int tag, Types ops, size_t length)
-        : Type(table, tag, ops)
+    VectorType(World& world, NodeTag tag, Defs ops, size_t length, Debug dbg)
+        : Type(world, tag, ops, dbg)
         , length_(length)
     {}
 
     hash_t vhash() const override { return hash_combine(Type::vhash(), length()); }
-    bool equal(const Type* other) const override {
-        return Type::equal(other) && this->length() == other->as<VectorType>()->length();
+    bool equal(const Def* other) const override {
+        return Def::equal(other) && this->length() == other->as<VectorType>()->length();
     }
 
 public:
@@ -202,15 +197,15 @@ inline size_t vector_length(const Type* type) { return type->as<VectorType>()->l
 /// Primitive type.
 class PrimType : public VectorType {
 private:
-    PrimType(TypeTable& table, PrimTypeTag tag, size_t length)
-        : VectorType(table, (int) tag, {}, length)
+    PrimType(World& world, PrimTypeTag tag, size_t length, Debug dbg)
+        : VectorType(world, (NodeTag) tag, Defs(), length, dbg)
     {}
 
 public:
     PrimTypeTag primtype_tag() const { return (PrimTypeTag) tag(); }
-    const Type* rebuild(TypeTable&, Types) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 inline bool is_primtype (const Type* t) { return thorin::is_primtype(t->tag()); }
@@ -238,30 +233,30 @@ enum class AddrSpace : uint32_t {
 };
 
 /// Pointer type.
-class PtrType : public VectorType {
+class PtrType : public VectorType, public TypeOpsMixin<TupleType> {
 private:
-    PtrType(TypeTable& table, const Type* pointee, size_t length, int32_t device, AddrSpace addr_space)
-        : VectorType(table, Node_PtrType, {pointee}, length)
+    PtrType(World& world, const Type* pointee, size_t length, int32_t device, AddrSpace addr_space, Debug dbg)
+        : VectorType(world, Node_PtrType, {pointee}, length, dbg)
         , addr_space_(addr_space)
         , device_(device)
     {}
 
 public:
-    const Type* pointee() const { return op(0); }
+    const Type* pointee() const { return op(0)->as<Type>(); }
     AddrSpace addr_space() const { return addr_space_; }
     int32_t device() const { return device_; }
     bool is_host_device() const { return device_ == -1; }
 
     hash_t vhash() const override;
-    bool equal(const Type* other) const override;
+    bool equal(const Def* other) const override;
 
 private:
-    const Type* rebuild(TypeTable&, Types) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
     AddrSpace addr_space_;
     int32_t device_;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 /// Returns true if the given type is small enough to fit in a closure environment
@@ -269,10 +264,10 @@ inline bool is_thin(const Type* type) {
     return type->isa<PrimType>() || type->isa<PtrType>() || is_type_unit(type);
 }
 
-class FnType : public Type {
+class FnType : public Type, public TypeOpsMixin<TupleType> {
 protected:
-    FnType(TypeTable& table, Types ops, int tag = Node_FnType)
-        : Type(table, tag, ops)
+    FnType(World& world, Defs ops, NodeTag tag, Debug dbg)
+        : Type(world, tag, ops, dbg)
     {
         ++order_;
     }
@@ -282,15 +277,15 @@ public:
     bool is_returning() const;
 
 private:
-    const Type* rebuild(TypeTable&, Types) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 class ClosureType : public FnType {
 private:
-    ClosureType(TypeTable& table, Types ops)
-        : FnType(table, ops, Node_ClosureType)
+    ClosureType(World& world, Defs ops, Debug dbg)
+        : FnType(world, ops, Node_ClosureType, dbg)
     {
         inner_order_ = order_;
         order_ = 0;
@@ -298,155 +293,84 @@ private:
 
 public:
     int inner_order() const { return inner_order_; }
-    const Type* rebuild(TypeTable&, Types) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
 private:
     int inner_order_;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 //------------------------------------------------------------------------------
 
-class ArrayType : public Type {
+class ArrayType : public Type, public TypeOpsMixin<TupleType> {
 protected:
-    ArrayType(TypeTable& table, int tag, const Type* elem_type)
-        : Type(table, tag, {elem_type})
+    ArrayType(World& world, NodeTag tag, const Type* elem_type, Debug dbg)
+        : Type(world, tag, {elem_type}, dbg)
     {}
 
 public:
-    const Type* elem_type() const { return op(0); }
+    const Type* elem_type() const { return op(0)->as<Type>(); }
 };
 
 class IndefiniteArrayType : public ArrayType {
 public:
-    IndefiniteArrayType(TypeTable& table, const Type* elem_type)
-        : ArrayType(table, Node_IndefiniteArrayType, elem_type)
+    IndefiniteArrayType(World& world, const Type* elem_type, Debug dbg)
+        : ArrayType(world, Node_IndefiniteArrayType, elem_type, dbg)
     {}
 
 private:
-    const Type* rebuild(TypeTable&, Types) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 class DefiniteArrayType : public ArrayType {
 public:
-    DefiniteArrayType(TypeTable& table, const Type* elem_type, u64 dim)
-        : ArrayType(table, Node_DefiniteArrayType, elem_type)
+    DefiniteArrayType(World& world, const Type* elem_type, u64 dim, Debug dbg)
+        : ArrayType(world, Node_DefiniteArrayType, elem_type, dbg)
         , dim_(dim)
     {}
 
     u64 dim() const { return dim_; }
     hash_t vhash() const override { return hash_combine(Type::vhash(), dim()); }
-    bool equal(const Type* other) const override {
-        return Type::equal(other) && this->dim() == other->as<DefiniteArrayType>()->dim();
+    bool equal(const Def* other) const override {
+        return Def::equal(other) && this->dim() == other->as<DefiniteArrayType>()->dim();
     }
 
 private:
-    const Type* rebuild(TypeTable&, Types) const override;
+    const Type* rebuild(World&, const Type*, Defs) const override;
 
     u64 dim_;
 
-    friend class TypeTable;
+    friend class World;
 };
 
 bool use_lea(const Type*);
 
 //------------------------------------------------------------------------------
 
-/// Container for all types. Types are hashed and can be compared using pointer equality.
 class TypeTable {
-private:
-    struct TypeHash {
-        static hash_t hash(const Type* t) { return t->hash(); }
-        static bool eq(const Type* t1, const Type* t2) { return t2->equal(t1); }
-        static const Type* sentinel() { return (const Type*)(1); }
-    };
-
-    typedef thorin::HashSet<const Type*, TypeHash> TypeSet;
-
 public:
-    TypeTable();
-
-    const Type* tuple_type(Types ops);
-    const TupleType* unit() { return unit_; } ///< Returns unit, i.e., an empty @p TupleType.
-    const VariantType* variant_type(Symbol name, size_t size);
-    const StructType* struct_type(Symbol name, size_t size);
-
-#define THORIN_ALL_TYPE(T, M) \
-    const PrimType* type_##T(size_t length = 1) { return prim_type(PrimType_##T, length); }
-#include "thorin/tables/primtypetable.h"
-    const PrimType* prim_type(PrimTypeTag tag, size_t length = 1);
-    const BottomType* bottom_type() const { return bottom_ty_; }
-    const MemType* mem_type() const { return mem_; }
-    const FrameType* frame_type() const { return frame_; }
-    const PtrType* ptr_type(const Type* pointee, size_t length = 1, int32_t device = -1, AddrSpace addr_space = AddrSpace::Generic);
-    const FnType* fn_type() { return fn0_; } ///< Returns an empty @p FnType.
-    const FnType* fn_type(Types args);
-    const ClosureType* closure_type(Types args);
-    const DefiniteArrayType*   definite_array_type(const Type* elem, u64 dim);
-    const IndefiniteArrayType* indefinite_array_type(const Type* elem);
-
-    const TypeSet& types() const { return types_; }
-
-    friend void swap(TypeTable& t1, TypeTable& t2) {
-        using std::swap;
-        swap(t1.types_, t2.types_);
-        swap(t1.unit_,  t2.unit_);
-        swap(t1.fn0_,   t2.fn0_);
-        swap(t1.bottom_ty_,   t2.bottom_ty_);
-        swap(t1.mem_,   t2.mem_);
-        swap(t1.frame_, t2.frame_);
-        std::swap_ranges(t1.primtypes_, t1.primtypes_ + Num_PrimTypes, t2.primtypes_);
-
-        t1.fix();
-        t2.fix();
-    }
+    explicit TypeTable(World& world);
 
 private:
-    void fix() {
-        for (auto type : types_)
-            type->table_ = this;
-    }
+    World& world_;
 
-    template <typename T, typename... Args>
-    const T* insert(Args&&... args);
-
-private:
-    TypeSet types_;
-
+    const Type* star_;
     const TupleType* unit_; ///< tuple().
     const FnType* fn0_;
     const BottomType* bottom_ty_;
     const MemType* mem_;
     const FrameType* frame_;
     const PrimType* primtypes_[Num_PrimTypes];
+
+    friend class World;
 };
 
 //------------------------------------------------------------------------------
 
-template<class T>
-struct GIDLt {
-    bool operator()(T a, T b) const { return a->gid() < b->gid(); }
-};
-
-template<class T>
-struct GIDHash {
-    static hash_t hash(T n) { return thorin::murmur3(n->gid()); }
-    static bool eq(T a, T b) { return a == b; }
-    static T sentinel() { return T(1); }
-};
-
-template<class Key, class Value>
-using GIDMap = thorin::HashMap<Key, Value, GIDHash<Key>>;
-template<class Key>
-using GIDSet = thorin::HashSet<Key, GIDHash<Key>>;
-
-template<class To>
-using TypeMap   = GIDMap<const Type*, To>;
-using Type2Type = TypeMap<const Type*>;
-using TypeSet   = GIDSet<const Type*>;
+inline bool is_mem        (const Def* def) { return def->type()->isa<MemType>(); }
 
 //------------------------------------------------------------------------------
 

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -27,6 +27,7 @@ protected:
 
 public:
     int order() const override { return order_; }
+    void set_op(size_t i, const Def *def) override;
     Stream& stream(Stream&) const;
 
     std::vector<const Type*> filter_type_ops() const {

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -16,7 +16,7 @@ class Type;
 using Types = ArrayRef<const Type*>;
 
 /// Base class for all \p Type%s.
-class Type : public Def, public Streamable<Type> {
+class Type : public Def {
 protected:
     /// Constructor for a @em structural Type.
     Type(World& w, NodeTag tag, const Type* type, Defs args, Debug dbg) : Def(w, tag, type, args, dbg) {}

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1276,28 +1276,32 @@ const Def* World::cse_base(const Def* def) {
  * optimizations
  */
 
-void World::cleanup() { cleanup_world(*this); }
+Thorin::Thorin(const std::string& name)
+    : world_(std::make_unique<World>(name))
+{}
 
-void World::opt() {
+void Thorin::cleanup() { cleanup_world(world_); }
+
+void Thorin::opt() {
 #define RUN_PASS(pass) \
 { \
-    VLOG("running pass {}", #pass); \
+    world().VLOG("running pass {}", #pass); \
     pass; \
-    debug_verify(*this); \
+    debug_verify(world()); \
 }
 
     RUN_PASS(cleanup())
-    RUN_PASS(while (partial_evaluation(*this, true))); // lower2cff
+    RUN_PASS(while (partial_evaluation(world(), true))); // lower2cff
     RUN_PASS(flatten_tuples(*this))
-    RUN_PASS(clone_bodies(*this))
+    RUN_PASS(clone_bodies(world()))
     RUN_PASS(split_slots(*this))
-    RUN_PASS(closure_conversion(*this))
+    RUN_PASS(closure_conversion(world()))
     RUN_PASS(lift_builtins(*this))
     RUN_PASS(inliner(*this))
     RUN_PASS(hoist_enters(*this))
-    RUN_PASS(dead_load_opt(*this))
+    RUN_PASS(dead_load_opt(world()))
     RUN_PASS(cleanup())
-    RUN_PASS(codegen_prepare(*this))
+    RUN_PASS(codegen_prepare(world()))
 }
 
 }

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -245,10 +245,6 @@ public:
     Continuation* end_scope() const { return data_.end_scope_; }
     const Filter* filter(const Defs, Debug dbg = {});
 
-    /// Performs dead code, unreachable code and unused type elimination.
-    void cleanup();
-    void opt();
-
     // getters
 
     const std::string& name() const { return data_.name_; }
@@ -310,14 +306,6 @@ public:
     static std::string colorize(const std::string& str, int color);
     //@}
 
-    friend void swap(World& w1, World& w2) {
-        using std::swap;
-        swap(static_cast<TypeTable&>(w1), static_cast<TypeTable&>(w2));
-        swap(w1.state_,  w2.state_);
-        swap(w1.data_,   w2.data_);
-        swap(w1.stream_, w2.stream_);
-    }
-
 private:
     const Param* param(const Type* type, Continuation* continuation, size_t index, Debug dbg);
     const App* app(const Def* callee, const Defs args, Debug dbg = {});
@@ -369,6 +357,21 @@ private:
     friend class Filter;
     friend class App;
     friend class Importer;
+    friend class Thorin;
+};
+
+class Thorin {
+public:
+    /// Initial world constructor
+    explicit Thorin(const std::string& name);
+
+    World& world() { return *world_; };
+
+    /// Performs dead code, unreachable code and unused type elimination.
+    void cleanup();
+    void opt();
+private:
+    std::unique_ptr<World> world_;
 };
 
 }

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -43,7 +43,7 @@ enum class LogLevel { Debug, Verbose, Info, Warn, Error };
  *  All worlds are completely independent from each other.
  *  This is particular useful for multi-threading.
  */
-class World : public TypeTable, public Streamable<World> {
+class World : public Streamable<World> {
 public:
     struct SeaHash {
         static hash_t hash(const Def* def) { return def->hash(); }
@@ -78,7 +78,6 @@ public:
         stream_ = other.stream_;
         state_  = other.state_;
     }
-    ~World();
 
     /// @name manage global identifier - a unique number for each Def
     //@{
@@ -90,11 +89,34 @@ public:
     //@{
     bool empty() { return data_.externals_.empty(); }
     const Externals& externals() const { return data_.externals_; }
-    void make_external(Continuation* cont) { data_.externals_.emplace(cont->unique_name(), cont); }
-    void make_internal(Continuation* cont) { data_.externals_.erase(cont->unique_name()); }
+    void make_external(Continuation* cont) { assert(&cont->world() == this); data_.externals_.emplace(cont->unique_name(), cont); }
+    void make_internal(Continuation* cont) { assert(&cont->world() == this); data_.externals_.erase(cont->unique_name()); }
     bool is_external(const Continuation* cont) { return data_.externals_.contains(cont->unique_name()); }
     Continuation* lookup(const std::string& name) { return data_.externals_.lookup(name).value_or(nullptr); }
     //@}
+
+    // types
+
+    const Type* star() { return types_.star_; }
+
+    const Type* tuple_type(Types ops);
+    const TupleType* unit_type() { return tuple_type({})->as<TupleType>(); } ///< Returns unit, i.e., an empty @p TupleType.
+    VariantType* variant_type(Symbol name, size_t size);
+    StructType* struct_type(Symbol name, size_t size);
+
+#define THORIN_ALL_TYPE(T, M) \
+    const PrimType* type_##T(size_t length = 1) { return prim_type(PrimType_##T, length); }
+#include "thorin/tables/primtypetable.h"
+    const PrimType* prim_type(PrimTypeTag tag, size_t length = 1);
+    const BottomType* bottom_type() { return make<BottomType>(*this, Debug()); }
+    const MemType* mem_type() { return make<MemType>(*this, Debug()); }
+    const FrameType* frame_type() { return make<FrameType>(*this, Debug()); }
+    const PtrType* ptr_type(const Type* pointee, size_t length = 1, int32_t device = -1, AddrSpace addr_space = AddrSpace::Generic);
+    const FnType* fn_type() { return fn_type({}); } ///< Returns an empty @p FnType.
+    const FnType* fn_type(Types args);
+    const ClosureType* closure_type(Types args);
+    const DefiniteArrayType*   definite_array_type(const Type* elem, u64 dim);
+    const IndefiniteArrayType* indefinite_array_type(const Type* elem);
 
     // literals
 
@@ -307,7 +329,7 @@ public:
     //@}
 
 private:
-    const Param* param(const Type* type, Continuation* continuation, size_t index, Debug dbg);
+    const Param* param(const Type* type, const Continuation*, size_t index, Debug dbg);
     const App* app(const Def* callee, const Defs args, Debug dbg = {});
     const Def* try_fold_aggregate(const Aggregate*);
     template <class F> const Def* transcendental(MathOpTag, const Def*, Debug, F&&);
@@ -317,6 +339,11 @@ private:
     //@{
     template <class T> const T* cse(const T* primop) { return cse_base(primop)->template as<T>(); }
     const Def* cse_base(const Def*);
+    template <class T, class... Args>
+    const T* make(Args&&... args) {
+        auto def = new T(args...);
+        return cse<T>(def);
+    }
 
     template<class T, class... Args>
     T* put(Args&&... args) {
@@ -349,15 +376,19 @@ private:
         Continuation* end_scope_;
     } data_;
 
+    TypeTable types_;
+
     std::shared_ptr<Stream> stream_;
 
     friend class Mangler;
     friend class Cleaner;
     friend class Continuation;
+    friend class Param;
     friend class Filter;
     friend class App;
     friend class Importer;
     friend class Thorin;
+    friend class TypeTable;
 };
 
 class Thorin {

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -110,8 +110,8 @@ public:
     const Def* one(const Type* type, Debug dbg = {}, size_t length = 1) { return one(type->as<PrimType>()->primtype_tag(), dbg, length); }
     const Def* allset(PrimTypeTag tag, Debug dbg = {}, size_t length = 1);
     const Def* allset(const Type* type, Debug dbg = {}, size_t length = 1) { return allset(type->as<PrimType>()->primtype_tag(), dbg, length); }
-    const Def* top(const Type* type, Debug dbg = {}, size_t length = 1) { return splat(cse(new Top(type, dbg)), length); }
-    const Def* bottom(const Type* type, Debug dbg = {}, size_t length = 1) { return splat(cse(new Bottom(type, dbg)), length); }
+    const Def* top(const Type* type, Debug dbg = {}, size_t length = 1) { return splat(cse(new Top(*this, type, dbg)), length); }
+    const Def* bottom(const Type* type, Debug dbg = {}, size_t length = 1) { return splat(cse(new Bottom(*this, type, dbg)), length); }
     const Def* bottom(PrimTypeTag tag, Debug dbg = {}, size_t length = 1) { return bottom(prim_type(tag), dbg, length); }
 
     // arithops
@@ -156,15 +156,15 @@ public:
         return cse(new IndefiniteArray(*this, elem, dim, dbg));
     }
     const Def* struct_agg(const StructType* struct_type, Defs args, Debug dbg = {}) {
-        return try_fold_aggregate(cse(new StructAgg(struct_type, args, dbg)));
+        return try_fold_aggregate(cse(new StructAgg(*this, struct_type, args, dbg)));
     }
     const Def* tuple(Defs args, Debug dbg = {}) { return args.size() == 1 ? args.front() : try_fold_aggregate(cse(new Tuple(*this, args, dbg))); }
 
-    const Def* variant(const VariantType* variant_type, const Def* value, size_t index, Debug dbg = {}) { return cse(new Variant(variant_type, value, index, dbg)); }
+    const Def* variant(const VariantType* variant_type, const Def* value, size_t index, Debug dbg = {}) { return cse(new Variant(*this, variant_type, value, index, dbg)); }
     const Def* variant_index  (const Def* value, Debug dbg = {});
     const Def* variant_extract(const Def* value, size_t index, Debug dbg = {});
 
-    const Def* closure(const ClosureType* closure_type, const Def* fn, const Def* env, Debug dbg = {}) { return cse(new Closure(closure_type, fn, env, dbg)); }
+    const Def* closure(const ClosureType* closure_type, const Def* fn, const Def* env, Debug dbg = {}) { return cse(new Closure(*this, closure_type, fn, env, dbg)); }
     const Def* vector(Defs args, Debug dbg = {}) {
         if (args.size() == 1) return args[0];
         return try_fold_aggregate(cse(new Vector(*this, args, dbg)));
@@ -216,7 +216,7 @@ public:
     const Def* load(const Def* mem, const Def* ptr, Debug dbg = {});
     const Def* store(const Def* mem, const Def* ptr, const Def* val, Debug dbg = {});
     const Def* enter(const Def* mem, Debug dbg = {});
-    const Def* slot(const Type* type, const Def* frame, Debug dbg = {}) { return cse(new Slot(type, frame, dbg)); }
+    const Def* slot(const Type* type, const Def* frame, Debug dbg = {}) { return cse(new Slot(*this, type, frame, dbg)); }
     const Def* alloc(const Type* type, const Def* mem, const Def* extra, Debug dbg = {});
     const Def* alloc(const Type* type, const Def* mem, Debug dbg = {}) { return alloc(type, mem, literal_qu64(0, dbg), dbg); }
     const Def* global(const Def* init, bool is_mutable = true, Debug dbg = {});


### PR DESCRIPTION
This (work-in-progress) PR makes `Type` a subtype of `Def`. This simplifies a fair bit and gets rid of some duplicated facilities in `World` and `TypeTable`. Additionally, the following adjustments were made:

 * All `Def`s received a `world` argument and currently store it as a field. This enables pervasive sanity checking during node construction, to ensure all the operands come from the same world.
 * `World`s are no longer mutated in-place through swapping their insides, instead a new `Thorin` class was created to contain the current world, and old worlds are discarded after importing. This is necessary to make the previous point work out, and is far less confusing to work with.
 * The `Importer` is now supplied with the destination world, instead of owning it
 * Nominal defs are now rebuilt using a pair of `stub()` and `rebuild_from()` virtual functions, rather than being special-cased in the `Importer`
 * `Param`s are now structural nodes
 * `Type`s operands are now defs, but a special `types()` helper is provided to access the type operands of struct types and such.
 * Because all defs have a `type()`, a new special `Star` (universe) node was added, to serve as the type of type-level defs and itself.
 * The `World` is now responsible for constructing and holding types - `TypeTable` still exists but only caches some of the simple types for speed.
 
 TODO:
  * Fix LLVM codegen issues
  * Unify/simplify the rewriting mechanisms (`Importer` vs `Rewriter`)