### PR TITLE
LLVM: Make the codegen more value-oriented, generalise jumping code

### DIFF
--- a/src/thorin/be/llvm/amdgpu.cpp
+++ b/src/thorin/be/llvm/amdgpu.cpp
@@ -86,7 +86,7 @@ llvm::Value* AMDGPUCodeGen::emit_mathop(llvm::IRBuilder<>& irbuilder, const Math
     return call;
 }
 
-Continuation* AMDGPUCodeGen::emit_reserve(llvm::IRBuilder<>& irbuilder, const Continuation* continuation) {
+llvm::Value* AMDGPUCodeGen::emit_reserve(llvm::IRBuilder<>& irbuilder, const Continuation* continuation) {
     return emit_reserve_shared(irbuilder, continuation, true);
 }
 

--- a/src/thorin/be/llvm/amdgpu.h
+++ b/src/thorin/be/llvm/amdgpu.h
@@ -22,7 +22,7 @@ protected:
     llvm::Function* emit_fun_decl(Continuation*) override;
     llvm::Value* emit_global(const Global*) override;
     llvm::Value* emit_mathop(llvm::IRBuilder<>&, const MathOp*) override;
-    Continuation* emit_reserve(llvm::IRBuilder<>&, const Continuation*) override;
+    llvm::Value* emit_reserve(llvm::IRBuilder<>&, const Continuation*) override;
     std::string get_alloc_name() const override { return "malloc"; }
 
     const Cont2Config& kernel_config_;

--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -449,6 +449,93 @@ void CodeGen::finalize(const Scope&) {
         defs_.erase(def);
 }
 
+std::vector<llvm::Value*> CodeGen::split_values(llvm::IRBuilder<>& irbuilder, Types domain, llvm::Value* value) {
+    size_t n = 0;
+    for (auto t : domain) {
+        if (t == world().unit_type() || t->isa<MemType>())
+            continue;
+        n++;
+    }
+
+    switch (n) {
+        case 0: return {};
+        case 1: return { value };
+        default: {
+            std::vector<llvm::Value*> values;
+            values.resize(n);
+            for (size_t i = 0; i < n; i++) {
+                values[i] = irbuilder.CreateExtractValue(value, i);
+            }
+            return values;
+        }
+    }
+}
+
+llvm::CallInst* CodeGen::emit_call(llvm::IRBuilder<>& irbuilder, const Def* callee, std::vector<llvm::Value*>& args) {
+    if (callee == entry_->ret_param()) { // normal return
+        std::vector<llvm::Type *> types;
+        for (auto val : args)
+            types.emplace_back(val->getType());
+        switch (args.size()) {
+            case 0:  irbuilder.CreateRetVoid();      break;
+            case 1:  irbuilder.CreateRet(args[0]); break;
+            default: {
+                llvm::Value* agg = llvm::UndefValue::get(llvm::StructType::get(context(), types));
+
+                for (size_t i = 0, e = args.size(); i != e; ++i)
+                    agg = irbuilder.CreateInsertValue(agg, args[i], { unsigned(i) });
+
+                irbuilder.CreateRet(agg);
+            }
+        }
+        return nullptr;
+    } else if (callee->isa<Bottom>()) {
+        irbuilder.CreateUnreachable();
+        return nullptr;
+    } else if (auto cont = callee->isa_nom<Continuation>(); cont && scope_->contains(cont) && cont != entry_) {
+        assert(cont->is_basicblock());
+        size_t j = 0, i = 0;
+        for (auto t: cont->type()->types()) {
+            i++;
+            assert(t->order() == 0);
+            if (t->isa<MemType>() || t == world().unit_type())
+                continue;
+            emit_phi_arg(irbuilder, cont->param(i - 1), args[j++]);
+        }
+        irbuilder.CreateBr(cont2bb(cont));
+        return nullptr;
+    } else if (auto closure_t = callee->type()->isa<ClosureType>()) {
+        auto closure = emit(callee);
+        auto fnt = world().fn_type(concat(closure_t->types(), closure_t->as<Type>()));
+        args.push_back(closure);
+        auto func = irbuilder.CreateExtractValue(closure, 0);
+        auto call = irbuilder.CreateCall(llvm::cast<llvm::FunctionType>(convert(fnt)), irbuilder.CreatePointerCast(func, convert(world().ptr_type(fnt))), args);
+        return call;
+    } else if (callee->type()->tag() == Node_FnType) {
+        auto call = irbuilder.CreateCall(llvm::cast<llvm::Function>(emit(callee)), args);
+        if (cont->is_exported())
+            call->setCallingConv(kernel_calling_convention_);
+        else if (cont->cc() == CC::Device)
+            call->setCallingConv(device_calling_convention_);
+        else
+            call->setCallingConv(function_calling_convention_);
+        return call;
+    }
+
+    THORIN_UNREACHABLE;
+}
+
+static const Type* mangle_for_codegen(World& world, ArrayRef<const Type*> ret_types) {
+    // treat non-returning calls as if they return nothing, for now
+    std::vector<const Type*> types;
+    for (auto op: ret_types) {
+        assert(op->order() == 0);
+        if (op->isa<MemType>() || is_type_unit(op)) continue;
+        types.push_back(op);
+    }
+    return world.tuple_type(types);
+}
+
 void CodeGen::emit_epilogue(Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
@@ -456,29 +543,9 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
     auto& [bb, ptr_irbuilder] = cont2bb_[continuation];
     auto& irbuilder = *ptr_irbuilder;
 
-    if (body->callee() == entry_->ret_param()) { // return
-        std::vector<llvm::Value*> values;
-        std::vector<llvm::Type *> types;
+    llvm::CallInst* call_instr = nullptr;
 
-        for (auto arg : body->args()) {
-            if (auto val = emit_unsafe(arg)) {
-                values.emplace_back(val);
-                types.emplace_back(val->getType());
-            }
-        }
-
-        switch (values.size()) {
-            case 0:  irbuilder.CreateRetVoid();      break;
-            case 1:  irbuilder.CreateRet(values[0]); break;
-            default:
-                llvm::Value* agg = llvm::UndefValue::get(llvm::StructType::get(context(), types));
-
-                for (size_t i = 0, e = values.size(); i != e; ++i)
-                    agg = irbuilder.CreateInsertValue(agg, values[i], { unsigned(i) });
-
-                irbuilder.CreateRet(agg);
-        }
-    } else if (body->callee() == world().branch()) {
+    if (body->callee() == world().branch()) {
         auto mem = body->arg(0);
         emit_unsafe(mem);
 
@@ -499,18 +566,11 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
             auto case_bb    = cont2bb(arg->op(1)->as_nom<Continuation>());
             match->addCase(case_const, case_bb);
         }
-    } else if (body->callee()->isa<Bottom>()) {
-        irbuilder.CreateUnreachable();
-    } else if (auto callee = body->callee()->isa_nom<Continuation>(); callee && callee->is_basicblock()) { // ordinary jump
-        for (size_t i = 0, e = body->num_args(); i != e; ++i) {
-            if (auto val = emit_unsafe(body->arg(i))) emit_phi_arg(irbuilder, callee->param(i), val);
-        }
-        irbuilder.CreateBr(cont2bb(callee));
     } else if (auto callee = body->callee()->isa_nom<Continuation>(); callee && callee->is_intrinsic()) {
-        auto ret_continuation = emit_intrinsic(irbuilder, continuation);
-        irbuilder.CreateBr(cont2bb(ret_continuation));
-    } else { // function/closure call
-        // put all first-order args into an array
+        auto args = emit_intrinsic(irbuilder, continuation);
+        call_instr = emit_call(irbuilder, body->arg(callee->ret_param()->index()), args);
+    } else {
+        // plain continuation call: we can just emit all the arguments
         std::vector<llvm::Value*> args;
         const Def* ret_arg = nullptr;
         for (auto arg : body->args()) {
@@ -523,61 +583,26 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
             }
         }
 
-        llvm::CallInst* call = nullptr;
-        if (auto callee = body->callee()->isa_nom<Continuation>()) {
-            call = irbuilder.CreateCall(llvm::cast<llvm::Function>(emit(callee)), args);
-            if (callee->is_exported())
-                call->setCallingConv(kernel_calling_convention_);
-            else if (callee->cc() == CC::Device)
-                call->setCallingConv(device_calling_convention_);
-            else
-                call->setCallingConv(function_calling_convention_);
-        } else {
-            // must be a closure
-            auto closure = emit(body->callee());
-            args.push_back(irbuilder.CreateExtractValue(closure, 1));
-            auto func = irbuilder.CreateExtractValue(closure, 0);
-            auto call_type = convert_closure_type(body->callee()->type());
-            call = irbuilder.CreateCall(call_type, func, args);
+        call_instr = emit_call(irbuilder, body->callee(), args);
+        if (body->callee()->type()->as<FnType>()->is_returning()) {
+            assert(call_instr && "returning calls always involve one of those");
+            assert(ret_arg && "we need a return argument too!");
+
+            auto ret_args = split_values(irbuilder, ret_arg->type()->as<FnType>()->types(), call_instr);
+            call_instr = emit_call(irbuilder, ret_arg, ret_args);
         }
+    }
 
-        // must be call + continuation --- call + return has been removed by codegen_prepare
-        auto succ = ret_arg->as_nom<Continuation>();
-
-        size_t n = 0;
-        const Param* last_param = nullptr;
-        for (auto param : succ->params()) {
-            if (is_mem(param) || is_unit(param))
-                continue;
-            last_param = param;
-            n++;
-        }
-
-        if (n == 0) {
-            irbuilder.CreateBr(cont2bb(succ));
-        } else if (n == 1) {
-            irbuilder.CreateBr(cont2bb(succ));
-            emit_phi_arg(irbuilder, last_param, call);
-        } else {
-            Array<llvm::Value*> extracts(n);
-            for (size_t i = 0, j = 0; i != succ->num_params(); ++i) {
-                auto param = succ->param(i);
-                if (is_mem(param) || is_unit(param))
-                    continue;
-                extracts[j] = irbuilder.CreateExtractValue(call, unsigned(j));
-                j++;
-            }
-
-            irbuilder.CreateBr(cont2bb(succ));
-
-            for (size_t i = 0, j = 0; i != succ->num_params(); ++i) {
-                auto param = succ->param(i);
-                if (is_mem(param) || is_unit(param))
-                    continue;
-                emit_phi_arg(irbuilder, param, extracts[j]);
-                j++;
-            }
-        }
+    if (call_instr) {
+        // we need to add a dummy return terminator if the last instruction is a call
+        if (entry_->type()->is_returning()) {
+            auto entry_return_t = mangle_for_codegen(world(), entry_->ret_param()->type()->as<FnType>()->types());
+            if (entry_return_t != world().unit_type()) {
+                irbuilder.CreateRet(llvm::UndefValue::get(convert(entry_return_t)));
+            } else
+                irbuilder.CreateRetVoid();
+        } else
+            irbuilder.CreateRetVoid();
     }
 
     // new insert point is just before the terminator for all other instructions we have to add later on
@@ -586,12 +611,14 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
 
 llvm::Value* CodeGen::emit_constant(const Def* def) {
     auto irbuilder = llvm::IRBuilder(context());
-    return emit_builder(irbuilder, def);
+    auto val = emit_builder(irbuilder, def);
+    return val;
 }
 
 llvm::Value* CodeGen::emit_bb(BB& bb, const Def* def) {
     auto& irbuilder = *bb.second;
-    return emit_builder(irbuilder, def);
+    auto val = emit_builder(irbuilder, def);
+    return val;
 }
 
 llvm::Value* CodeGen::emit_builder(llvm::IRBuilder<>& irbuilder, const Def* def) {
@@ -1221,7 +1248,7 @@ llvm::Value* CodeGen::emit_assembly(llvm::IRBuilder<>& irbuilder, const Assembly
  * emit intrinsic
  */
 
-Continuation* CodeGen::emit_intrinsic(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+std::vector<llvm::Value*> CodeGen::emit_intrinsic(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     auto callee = body->callee()->as_nom<Continuation>();
@@ -1236,33 +1263,35 @@ Continuation* CodeGen::emit_intrinsic(llvm::IRBuilder<>& irbuilder, Continuation
     }
 
     switch (callee->intrinsic()) {
-        case Intrinsic::Atomic:       return emit_atomic(irbuilder, continuation);
-        case Intrinsic::AtomicLoad:   return emit_atomic_load(irbuilder, continuation);
-        case Intrinsic::AtomicStore:  return emit_atomic_store(irbuilder, continuation);
+        case Intrinsic::Atomic:       return { emit_atomic(irbuilder, continuation) };
+        case Intrinsic::AtomicLoad:   return { emit_atomic_load(irbuilder, continuation) };
+        case Intrinsic::AtomicStore:  emit_atomic_store(irbuilder, continuation); break;
         case Intrinsic::CmpXchg:      return emit_cmpxchg(irbuilder, continuation, false);
         case Intrinsic::CmpXchgWeak:  return emit_cmpxchg(irbuilder, continuation, true);
-        case Intrinsic::Fence:        return emit_fence(irbuilder, continuation);
-        case Intrinsic::Reserve:      return emit_reserve(irbuilder, continuation);
-        case Intrinsic::CUDA:         return runtime_->emit_host_code(*this, irbuilder, Runtime::CUDA_PLATFORM,   ".cu",     continuation);
-        case Intrinsic::NVVM:         return runtime_->emit_host_code(*this, irbuilder, Runtime::CUDA_PLATFORM,   ".nvvm",   continuation);
-        case Intrinsic::OpenCL:       return runtime_->emit_host_code(*this, irbuilder, Runtime::OPENCL_PLATFORM, ".cl",     continuation);
-        case Intrinsic::AMDGPU:       return runtime_->emit_host_code(*this, irbuilder, Runtime::HSA_PLATFORM,    ".amdgpu", continuation);
-        case Intrinsic::ShadyCompute: return runtime_->emit_host_code(*this, irbuilder, Runtime::SHADY_PLATFORM,  ".shady",  continuation);
-        case Intrinsic::HLS:          return emit_hls(irbuilder, continuation);
-        case Intrinsic::Parallel:     return emit_parallel(irbuilder, continuation);
-        case Intrinsic::Fibers:       return emit_fibers(irbuilder, continuation);
-        case Intrinsic::Spawn:        return emit_spawn(irbuilder, continuation);
-        case Intrinsic::Sync:         return emit_sync(irbuilder, continuation);
+        case Intrinsic::Fence:        emit_fence(irbuilder, continuation); break;
+        case Intrinsic::Reserve:      return { emit_reserve(irbuilder, continuation) };
+        case Intrinsic::CUDA:         runtime_->emit_host_code(*this, irbuilder, Runtime::CUDA_PLATFORM,   ".cu",     continuation); break;
+        case Intrinsic::NVVM:         runtime_->emit_host_code(*this, irbuilder, Runtime::CUDA_PLATFORM,   ".nvvm",   continuation); break;
+        case Intrinsic::OpenCL:       runtime_->emit_host_code(*this, irbuilder, Runtime::OPENCL_PLATFORM, ".cl",     continuation); break;
+        case Intrinsic::AMDGPU:       runtime_->emit_host_code(*this, irbuilder, Runtime::HSA_PLATFORM,    ".amdgpu", continuation); break;
+        case Intrinsic::ShadyCompute: runtime_->emit_host_code(*this, irbuilder, Runtime::SHADY_PLATFORM,  ".shady",  continuation); break;
+        case Intrinsic::HLS:          emit_hls(irbuilder, continuation);      break;
+        case Intrinsic::Parallel:     emit_parallel(irbuilder, continuation); break;
+        case Intrinsic::Fibers:       emit_fibers(irbuilder, continuation);   break;
+        case Intrinsic::Spawn:        return { emit_spawn(irbuilder, continuation) };
+        case Intrinsic::Sync:         emit_sync(irbuilder, continuation);     break;
 #if THORIN_ENABLE_RV
-        case Intrinsic::Vectorize:   return emit_vectorize_continuation(irbuilder, continuation);
+        case Intrinsic::Vectorize:    emit_vectorize_continuation(irbuilder, continuation); break;
 #else
-        case Intrinsic::Vectorize:   throw std::runtime_error("rebuild with RV support");
+        case Intrinsic::Vectorize:    throw std::runtime_error("rebuild with RV support");
 #endif
         default: THORIN_UNREACHABLE;
     }
+
+    return {};
 }
 
-Continuation* CodeGen::emit_atomic(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+llvm::Value* CodeGen::emit_atomic(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     assert(body->num_args() == 7 && "required arguments are missing");
@@ -1282,13 +1311,11 @@ Continuation* CodeGen::emit_atomic(llvm::IRBuilder<>& irbuilder, Continuation* c
     assert(int(llvm::AtomicOrdering::NotAtomic) <= int(order_tag) && int(order_tag) <= int(llvm::AtomicOrdering::SequentiallyConsistent) && "unsupported atomic ordering");
     auto order = (llvm::AtomicOrdering)order_tag;
     auto scope = body->arg(5)->as<ConvOp>()->from()->as<Global>()->init()->as<DefiniteArray>();
-    auto cont = body->arg(6)->as_nom<Continuation>();
     auto call = irbuilder.CreateAtomicRMW(binop, ptr, val, llvm::MaybeAlign(), order, context().getOrInsertSyncScopeID(scope->as_string()));
-    emit_phi_arg(irbuilder, cont->param(1), call);
-    return cont;
+    return call;
 }
 
-Continuation* CodeGen::emit_atomic_load(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+llvm::Value* CodeGen::emit_atomic_load(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     assert(body->num_args() == 5 && "required arguments are missing");
@@ -1303,11 +1330,10 @@ Continuation* CodeGen::emit_atomic_load(llvm::IRBuilder<>& irbuilder, Continuati
     auto align = module().getDataLayout().getABITypeAlign(load_type);
     load->setAlignment(align);
     load->setAtomic(order, context().getOrInsertSyncScopeID(scope->as_string()));
-    emit_phi_arg(irbuilder, cont->param(1), load);
-    return cont;
+    return load;
 }
 
-Continuation* CodeGen::emit_atomic_store(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+void CodeGen::emit_atomic_store(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     assert(body->num_args() == 6 && "required arguments are missing");
@@ -1322,10 +1348,9 @@ Continuation* CodeGen::emit_atomic_store(llvm::IRBuilder<>& irbuilder, Continuat
     auto align = module().getDataLayout().getABITypeAlign(convert(body->arg(2)->type()));
     store->setAlignment(align);
     store->setAtomic(order, context().getOrInsertSyncScopeID(scope->as_string()));
-    return cont;
 }
 
-Continuation* CodeGen::emit_cmpxchg(llvm::IRBuilder<>& irbuilder, Continuation* continuation, bool is_weak) {
+std::vector<llvm::Value*> CodeGen::emit_cmpxchg(llvm::IRBuilder<>& irbuilder, Continuation* continuation, bool is_weak) {
     assert(continuation->has_body());
     auto body = continuation->body();
 
@@ -1345,12 +1370,10 @@ Continuation* CodeGen::emit_cmpxchg(llvm::IRBuilder<>& irbuilder, Continuation* 
     auto cont = body->arg(7)->as_nom<Continuation>();
     auto call = irbuilder.CreateAtomicCmpXchg(ptr, cmp, val, llvm::MaybeAlign(), success_order, failure_order, context().getOrInsertSyncScopeID(scope->as_string()));
     call->setWeak(is_weak);
-    emit_phi_arg(irbuilder, cont->param(1), irbuilder.CreateExtractValue(call, 0));
-    emit_phi_arg(irbuilder, cont->param(2), irbuilder.CreateExtractValue(call, 1));
-    return cont;
+    return { irbuilder.CreateExtractValue(call, 0), irbuilder.CreateExtractValue(call, 1) };
 }
 
-Continuation* CodeGen::emit_fence(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+void CodeGen::emit_fence(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     assert(body->num_args() == 4 && "required arguments are missing");
@@ -1360,15 +1383,14 @@ Continuation* CodeGen::emit_fence(llvm::IRBuilder<>& irbuilder, Continuation* co
     auto scope = body->arg(2)->as<ConvOp>()->from()->as<Global>()->init()->as<DefiniteArray>();
     auto cont = body->arg(3)->as_nom<Continuation>();
     irbuilder.CreateFence(order, context().getOrInsertSyncScopeID(scope->as_string()));
-    return cont;
 }
 
-Continuation* CodeGen::emit_reserve(llvm::IRBuilder<>&, const Continuation* continuation) {
+llvm::Value* CodeGen::emit_reserve(llvm::IRBuilder<>&, const Continuation* continuation) {
     world().edef(continuation, "reserve_shared: only allowed in device code"); // TODO debug
     THORIN_UNREACHABLE;
 }
 
-Continuation* CodeGen::emit_reserve_shared(llvm::IRBuilder<>& irbuilder, const Continuation* continuation, bool init_undef) {
+llvm::Value* CodeGen::emit_reserve_shared(llvm::IRBuilder<>& irbuilder, const Continuation* continuation, bool init_undef) {
     assert(continuation->has_body());
     auto body = continuation->body();
     assert(body->num_args() == 3 && "required arguments are missing");
@@ -1385,31 +1407,23 @@ Continuation* CodeGen::emit_reserve_shared(llvm::IRBuilder<>& irbuilder, const C
     std::replace(name.begin(), name.end(), '.', '_');
     auto global = emit_global_variable(smem_type, name, 3, init_undef);
     auto call = irbuilder.CreatePointerCast(global, type);
-    emit_phi_arg(irbuilder, cont->param(1), call);
-    return cont;
+    return call;
 }
 
 /*
  * backend-specific stuff
  */
 
-Continuation* CodeGen::emit_hls(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+void CodeGen::emit_hls(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     std::vector<llvm::Value*> args(body->num_args()-3);
-    Continuation* ret = nullptr;
     for (size_t i = 2, j = 0; i < body->num_args(); ++i) {
-        if (auto cont = body->arg(i)->isa_nom<Continuation>()) {
-            ret = cont;
-            continue;
-        }
         args[j++] = emit(body->arg(i));
     }
     auto callee = body->arg(1)->as<Global>()->init()->as_nom<Continuation>();
     world().make_external(callee);
     irbuilder.CreateCall(emit_fun_decl(callee), args);
-    assert(ret);
-    return ret;
 }
 
 /*

--- a/src/thorin/be/llvm/llvm.h
+++ b/src/thorin/be/llvm/llvm.h
@@ -83,8 +83,8 @@ protected:
     virtual llvm::Value* emit_lea     (llvm::IRBuilder<>&, const LEA*);
     virtual llvm::Value* emit_assembly(llvm::IRBuilder<>&, const Assembly* assembly);
 
-    virtual Continuation* emit_reserve(llvm::IRBuilder<>&, const Continuation*);
-    Continuation* emit_reserve_shared(llvm::IRBuilder<>&, const Continuation*, bool=false);
+    virtual llvm::Value* emit_reserve(llvm::IRBuilder<>&, const Continuation*);
+    llvm::Value* emit_reserve_shared(llvm::IRBuilder<>&, const Continuation*, bool=false);
 
     virtual std::string get_alloc_name() const = 0;
     llvm::BasicBlock* cont2bb(Continuation* cont) { return cont2bb_[cont].first; }
@@ -96,23 +96,26 @@ protected:
     void verify() const;
     void create_loop(llvm::IRBuilder<>&, llvm::Value*, llvm::Value*, llvm::Value*, llvm::Function*, std::function<void(llvm::Value*)>);
     llvm::Value* create_tmp_alloca(llvm::IRBuilder<>&, llvm::Type*, std::function<llvm::Value* (llvm::AllocaInst*)>);
-
     llvm::Value* call_math_function(llvm::IRBuilder<>&, const MathOp*, const std::string&);
+
+    std::vector<llvm::Value*> split_values(llvm::IRBuilder<>&, Types domain, llvm::Value* value);
+    /// Emits a 'call' using already emitted arguments. Returns the call instruction if appropriate
+    llvm::CallInst* emit_call(llvm::IRBuilder<>&, const Def* callee, std::vector<llvm::Value*>& args);
 
 private:
     Continuation* emit_peinfo(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_intrinsic(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_hls(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_parallel(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_fibers(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_spawn(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_sync(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_vectorize_continuation(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_atomic(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_cmpxchg(llvm::IRBuilder<>&, Continuation*, bool);
-    Continuation* emit_fence(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_atomic_load(llvm::IRBuilder<>&, Continuation*);
-    Continuation* emit_atomic_store(llvm::IRBuilder<>&, Continuation*);
+    std::vector<llvm::Value*> emit_intrinsic(llvm::IRBuilder<>&, Continuation*);
+    void emit_hls(llvm::IRBuilder<>&, Continuation*);
+    void emit_parallel(llvm::IRBuilder<>&, Continuation*);
+    void emit_fibers(llvm::IRBuilder<>&, Continuation*);
+    llvm::Value* emit_spawn(llvm::IRBuilder<>&, Continuation*);
+    void emit_sync(llvm::IRBuilder<>&, Continuation*);
+    void emit_vectorize_continuation(llvm::IRBuilder<>&, Continuation*);
+    llvm::Value* emit_atomic(llvm::IRBuilder<>&, Continuation*);
+    std::vector<llvm::Value*> emit_cmpxchg(llvm::IRBuilder<>&, Continuation*, bool);
+    void emit_fence(llvm::IRBuilder<>&, Continuation*);
+    llvm::Value* emit_atomic_load(llvm::IRBuilder<>&, Continuation*);
+    void emit_atomic_store(llvm::IRBuilder<>&, Continuation*);
     llvm::Value* emit_bitcast(llvm::IRBuilder<>&, const Def*, const Type*);
     void emit_vectorize(u32, llvm::Function*, llvm::CallInst*);
     void emit_phi_arg(llvm::IRBuilder<>&, const Param*, llvm::Value*);

--- a/src/thorin/be/llvm/nvvm.cpp
+++ b/src/thorin/be/llvm/nvvm.cpp
@@ -242,7 +242,7 @@ llvm::Value* NVVMCodeGen::emit_lea(llvm::IRBuilder<>& irbuilder, const LEA* lea)
     }
 }
 
-Continuation* NVVMCodeGen::emit_reserve(llvm::IRBuilder<>& irbuilder, const Continuation* continuation) {
+llvm::Value* NVVMCodeGen::emit_reserve(llvm::IRBuilder<>& irbuilder, const Continuation* continuation) {
     return emit_reserve_shared(irbuilder, continuation);
 }
 

--- a/src/thorin/be/llvm/nvvm.h
+++ b/src/thorin/be/llvm/nvvm.h
@@ -28,7 +28,7 @@ protected:
     llvm::Value* emit_lea(llvm::IRBuilder<>&,    const LEA*) override;
     llvm::Value* emit_mathop(llvm::IRBuilder<>&, const MathOp*) override;
 
-    Continuation* emit_reserve(llvm::IRBuilder<>&, const Continuation*) override;
+    llvm::Value* emit_reserve(llvm::IRBuilder<>&, const Continuation*) override;
 
     llvm::Value* emit_global(const Global*) override;
 

--- a/src/thorin/be/llvm/parallel.cpp
+++ b/src/thorin/be/llvm/parallel.cpp
@@ -12,7 +12,7 @@ enum {
     PAR_NUM_ARGS
 };
 
-Continuation* CodeGen::emit_parallel(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+void CodeGen::emit_parallel(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     // Emit memory dependencies up to this point
@@ -36,7 +36,7 @@ Continuation* CodeGen::emit_parallel(llvm::IRBuilder<>& irbuilder, Continuation*
     }
 
     // fetch values and create a unified struct which contains all values (closure)
-    auto closure_type = convert(world().tuple_type(continuation->arg_fn_type()->types().skip_front(PAR_NUM_ARGS)));
+    auto closure_type = convert(world().tuple_type(continuation->body()->callee()->type()->as<FnType>()->types().skip_front(PAR_NUM_ARGS)));
     llvm::Value* closure = llvm::UndefValue::get(closure_type);
     if (num_kernel_args != 1) {
         for (size_t i = 0; i < num_kernel_args; ++i)
@@ -91,8 +91,6 @@ Continuation* CodeGen::emit_parallel(llvm::IRBuilder<>& irbuilder, Continuation*
 
     // restore old insert point
     irbuilder.SetInsertPoint(old_bb);
-
-    return body->arg(PAR_ARG_RETURN)->as_nom<Continuation>();
 }
 
 enum {
@@ -105,7 +103,7 @@ enum {
     FIB_NUM_ARGS
 };
 
-Continuation* CodeGen::emit_fibers(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+void CodeGen::emit_fibers(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     // Emit memory dependencies up to this point
@@ -183,8 +181,6 @@ Continuation* CodeGen::emit_fibers(llvm::IRBuilder<>& irbuilder, Continuation* c
 
     // restore old insert point
     irbuilder.SetInsertPoint(old_bb);
-
-    return body->arg(FIB_ARG_RETURN)->as_nom<Continuation>();
 }
 
 enum {
@@ -194,7 +190,7 @@ enum {
     SPAWN_NUM_ARGS
 };
 
-Continuation* CodeGen::emit_spawn(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+llvm::Value* CodeGen::emit_spawn(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     assert(body->num_args() >= SPAWN_NUM_ARGS && "required arguments are missing");
@@ -213,7 +209,7 @@ Continuation* CodeGen::emit_spawn(llvm::IRBuilder<>& irbuilder, Continuation* co
     }
 
     // fetch values and create a unified struct which contains all values (closure)
-    auto closure_type = convert(world().tuple_type(continuation->arg_fn_type()->types().skip_front(SPAWN_NUM_ARGS)));
+    auto closure_type = convert(world().tuple_type(continuation->body()->callee()->type()->as<FnType>()->types().skip_front(SPAWN_NUM_ARGS)));
     llvm::Value* closure = nullptr;
     if (closure_type->isStructTy()) {
         closure = llvm::UndefValue::get(closure_type);
@@ -262,10 +258,7 @@ Continuation* CodeGen::emit_spawn(llvm::IRBuilder<>& irbuilder, Continuation* co
     // restore old insert point
     irbuilder.SetInsertPoint(old_bb);
 
-    // bind parameter of continuation to received handle
-    auto cont = body->arg(SPAWN_ARG_RETURN)->as_nom<Continuation>();
-    emit_phi_arg(irbuilder, cont->param(1), call);
-    return cont;
+    return call;
 }
 
 enum {
@@ -275,7 +268,7 @@ enum {
     SYNC_NUM_ARGS
 };
 
-Continuation* CodeGen::emit_sync(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+void CodeGen::emit_sync(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     assert(body->num_args() == SYNC_NUM_ARGS && "wrong number of arguments");
@@ -285,7 +278,6 @@ Continuation* CodeGen::emit_sync(llvm::IRBuilder<>& irbuilder, Continuation* con
 
     auto id = emit(body->arg(SYNC_ARG_ID));
     runtime_->sync_thread(*this, irbuilder, id);
-    return body->arg(SYNC_ARG_RETURN)->as_nom<Continuation>();
 }
 
 }

--- a/src/thorin/be/llvm/runtime.cpp
+++ b/src/thorin/be/llvm/runtime.cpp
@@ -60,7 +60,7 @@ static bool contains_ptrtype(const Type* type) {
     }
 }
 
-Continuation* Runtime::emit_host_code(CodeGen& code_gen, llvm::IRBuilder<>& builder, Platform platform, const std::string& ext, Continuation* continuation) {
+void Runtime::emit_host_code(CodeGen& code_gen, llvm::IRBuilder<>& builder, Platform platform, const std::string& ext, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     // to-target is the desired kernel call
@@ -184,8 +184,6 @@ Continuation* Runtime::emit_host_code(CodeGen& code_gen, llvm::IRBuilder<>& buil
                   grid_size, block_size,
                   args, sizes, aligns, allocs, types,
                   builder.getInt32(num_kernel_args));
-
-    return body->arg(LaunchArgs::Return)->as_nom<Continuation>();
 }
 
 llvm::Value* Runtime::launch_kernel(

--- a/src/thorin/be/llvm/runtime.h
+++ b/src/thorin/be/llvm/runtime.h
@@ -51,7 +51,7 @@ public:
     /// Emits a call to anydsl_sync_thread.
     llvm::Value* sync_thread(CodeGen&, llvm::IRBuilder<>&, llvm::Value* id);
 
-    Continuation* emit_host_code(
+    void emit_host_code(
         CodeGen& code_gen, llvm::IRBuilder<>& builder,
         Platform platform, const std::string& ext, Continuation* continuation);
 

--- a/src/thorin/be/llvm/vectorize.cpp
+++ b/src/thorin/be/llvm/vectorize.cpp
@@ -48,7 +48,7 @@ struct VectorizeArgs {
     };
 };
 
-Continuation* CodeGen::emit_vectorize_continuation(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
+void CodeGen::emit_vectorize_continuation(llvm::IRBuilder<>& irbuilder, Continuation* continuation) {
     assert(continuation->has_body());
     auto body = continuation->body();
     auto target = body->callee()->as_nom<Continuation>();
@@ -93,8 +93,6 @@ Continuation* CodeGen::emit_vectorize_continuation(llvm::IRBuilder<>& irbuilder,
         world().edef(body->arg(VectorizeArgs::Length), "vector length must be known at compile-time");
     u32 vector_length_constant = body->arg(VectorizeArgs::Length)->as<PrimLit>()->qu32_value();
     vec_todo_.emplace_back(vector_length_constant, emit_fun_decl(kernel), simd_kernel_call);
-
-    return body->arg(VectorizeArgs::Return)->as_nom<Continuation>();
 }
 
 void CodeGen::emit_vectorize(u32 vector_length, llvm::Function* kernel_func, llvm::CallInst* simd_kernel_call) {


### PR DESCRIPTION
This PR refactors the LLVM backend to be a bit simpler when it comes to dealing with calling continuations.

It introduces `emit_call` which is used to emit any sort of calls: it handles calling basic blocks, functions, closures, bottom/unreachable as well as calling the return parameter of a function.

It's interesting to lift it out as it's own function, different from emit_epilogue, because often we generate an unconditional jump as part of emitting an intrinsic, or a direct-style (returning) call. This simplifies the backend a bit because now there is only one place where LLVM branches are actually emitted.

Furthermore, emitting calls to intrinsics was simplified and now emit_intrinsic* functions all return values, leaving `emit_epiloguel` the responsibility of calling the next continuation through `emit_call`.

## Testing results

Rodent builds and works, Artic tests all pass, Stincilla builds and passes tests.