### PR TITLE
Add PAL-based backend for AMD GPUs

### DIFF
--- a/src/thorin/CMakeLists.txt
+++ b/src/thorin/CMakeLists.txt
@@ -95,8 +95,10 @@ if(LLVM_FOUND)
         be/llvm/cpu.h
         be/llvm/llvm.cpp
         be/llvm/llvm.h
-        be/llvm/amdgpu.cpp
-        be/llvm/amdgpu.h
+        be/llvm/amdgpu_hsa.cpp
+        be/llvm/amdgpu_hsa.h
+        be/llvm/amdgpu_pal.cpp
+        be/llvm/amdgpu_pal.h
         be/llvm/nvvm.cpp
         be/llvm/nvvm.h
         be/llvm/parallel.cpp

--- a/src/thorin/be/codegen.h
+++ b/src/thorin/be/codegen.h
@@ -44,7 +44,7 @@ struct DeviceBackends {
     Cont2Config kernel_config;
     std::vector<Continuation*> kernels;
 
-    enum { CUDA, NVVM, OpenCL, AMDGPU, HLS, BackendCount };
+    enum { CUDA, NVVM, OpenCL, AMDGPU_HSA, AMDGPU_PAL, HLS, BackendCount };
     std::array<std::unique_ptr<CodeGen>, BackendCount> cgs;
 private:
     std::vector<Importer> importers_;

--- a/src/thorin/be/llvm/amdgpu_hsa.cpp
+++ b/src/thorin/be/llvm/amdgpu_hsa.cpp
@@ -1,0 +1,91 @@
+#include "thorin/be/llvm/amdgpu_hsa.h"
+
+#include <unordered_map> // TODO don't use std::unordered_*
+
+#include "thorin/primop.h"
+#include "thorin/world.h"
+
+namespace thorin::llvm {
+
+AMDGPUHSACodeGen::AMDGPUHSACodeGen(World& world, const Cont2Config& kernel_config, int opt, bool debug)
+    : CodeGen(world, llvm::CallingConv::C, llvm::CallingConv::C, llvm::CallingConv::AMDGPU_KERNEL, opt, debug)
+    , kernel_config_(kernel_config)
+{
+    module().setDataLayout("e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7");
+    module().setTargetTriple("amdgcn-amd-amdhsa");
+}
+
+//------------------------------------------------------------------------------
+// Kernel code
+//------------------------------------------------------------------------------
+
+void AMDGPUHSACodeGen::emit_fun_decl_hook(Continuation* continuation, llvm::Function* f) {
+    auto config = kernel_config_.find(continuation);
+    if (config != kernel_config_.end()) {
+        auto block = config->second->as<GPUKernelConfig>()->block_size();
+        if (std::get<0>(block) > 0 && std::get<1>(block) > 0 && std::get<2>(block) > 0) {
+            Array<llvm::Metadata*> annotation_values_wgsize(3);
+            auto int32_type = llvm::IntegerType::get(context(), 32);
+            annotation_values_wgsize[0] = llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(int32_type, std::get<0>(block)));
+            annotation_values_wgsize[1] = llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(int32_type, std::get<1>(block)));
+            annotation_values_wgsize[2] = llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(int32_type, std::get<2>(block)));
+            f->setMetadata(llvm::StringRef("reqd_work_group_size"), llvm::MDNode::get(context(), llvm_ref(annotation_values_wgsize)));
+        }
+    }
+}
+
+llvm::Function* AMDGPUHSACodeGen::emit_fun_decl(Continuation* continuation) {
+    if (continuation->name() == "llvm.amdgcn.implicitarg.ptr")
+        if (auto f = defs_.lookup(entry_); f && llvm::isa<llvm::Function>(*f))
+            llvm::cast<llvm::Function>(*f)->addFnAttr("amdgpu-implicitarg-ptr");
+    if (continuation->name() == "__ockl_printf_begin")
+        if (auto f = defs_.lookup(entry_); f && llvm::isa<llvm::Function>(*f))
+            llvm::cast<llvm::Function>(*f)->addFnAttr("amdgpu-implicitarg-num-bytes", "32");
+    return CodeGen::emit_fun_decl(continuation);
+}
+
+llvm::Value* AMDGPUHSACodeGen::emit_global(const Global* global) {
+    if (global->is_mutable())
+        world().wdef(global, "AMDGPU: Global variable '{}' will not be synced with host", global);
+    return CodeGen::emit_global(global);
+}
+
+llvm::Value* AMDGPUHSACodeGen::emit_mathop(llvm::IRBuilder<>& irbuilder, const MathOp* mathop) {
+    auto make_key = [] (MathOpTag tag, unsigned bitwidth) { return (static_cast<unsigned>(tag) << 16) | bitwidth; };
+    static const std::unordered_map<unsigned, std::string> ocml_functions = {
+#define MATH_FUNCTION(name) \
+        { make_key(MathOp_##name, 32), "__ocml_" #name "_f32" }, \
+        { make_key(MathOp_##name, 64), "__ocml_" #name "_f64" },
+        MATH_FUNCTION(fabs)
+        MATH_FUNCTION(copysign)
+        MATH_FUNCTION(round)
+        MATH_FUNCTION(floor)
+        MATH_FUNCTION(ceil)
+        MATH_FUNCTION(fmin)
+        MATH_FUNCTION(fmax)
+        MATH_FUNCTION(cos)
+        MATH_FUNCTION(sin)
+        MATH_FUNCTION(tan)
+        MATH_FUNCTION(acos)
+        MATH_FUNCTION(asin)
+        MATH_FUNCTION(atan)
+        MATH_FUNCTION(atan2)
+        MATH_FUNCTION(sqrt)
+        MATH_FUNCTION(cbrt)
+        MATH_FUNCTION(pow)
+        MATH_FUNCTION(exp)
+        MATH_FUNCTION(exp2)
+        MATH_FUNCTION(log)
+        MATH_FUNCTION(log2)
+        MATH_FUNCTION(log10)
+#undef MATH_FUNCTION
+    };
+    auto key = make_key(mathop->mathop_tag(), num_bits(mathop->type()->primtype_tag()));
+    return call_math_function(irbuilder, mathop, ocml_functions.at(key));
+}
+
+Continuation* AMDGPUHSACodeGen::emit_reserve(llvm::IRBuilder<>& irbuilder, const Continuation* continuation) {
+    return emit_reserve_shared(irbuilder, continuation, true);
+}
+
+}

--- a/src/thorin/be/llvm/amdgpu_hsa.h
+++ b/src/thorin/be/llvm/amdgpu_hsa.h
@@ -1,5 +1,5 @@
-#ifndef THORIN_BE_LLVM_AMDGPU_H
-#define THORIN_BE_LLVM_AMDGPU_H
+#ifndef THORIN_BE_LLVM_AMDGPU_HSA_H
+#define THORIN_BE_LLVM_AMDGPU_HSA_H
 
 #include "thorin/be/llvm/llvm.h"
 
@@ -11,9 +11,9 @@ namespace llvm {
 
 namespace llvm = ::llvm;
 
-class AMDGPUCodeGen : public CodeGen {
+class AMDGPUHSACodeGen : public CodeGen {
 public:
-    AMDGPUCodeGen(World& world, const Cont2Config&, int opt, bool debug);
+    AMDGPUHSACodeGen(World& world, const Cont2Config&, int opt, bool debug);
 
     const char* file_ext() const override { return ".amdgpu"; }
 

--- a/src/thorin/be/llvm/amdgpu_pal.cpp
+++ b/src/thorin/be/llvm/amdgpu_pal.cpp
@@ -8,7 +8,7 @@
 namespace thorin::llvm {
 
 AMDGPUPALCodeGen::AMDGPUPALCodeGen(World& world, const Cont2Config& kernel_config, int opt, bool debug)
-    : CodeGen(world, llvm::CallingConv::C, llvm::CallingConv::C, llvm::CallingConv::AMDGPU_KERNEL, opt, debug)
+    : CodeGen(world, llvm::CallingConv::C, llvm::CallingConv::C, llvm::CallingConv::AMDGPU_CS, opt, debug)
     , kernel_config_(kernel_config)
 {
     module().setDataLayout("e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7");

--- a/src/thorin/be/llvm/amdgpu_pal.cpp
+++ b/src/thorin/be/llvm/amdgpu_pal.cpp
@@ -1,4 +1,4 @@
-#include "thorin/be/llvm/amdgpu.h"
+#include "thorin/be/llvm/amdgpu_pal.h"
 
 #include <unordered_map> // TODO don't use std::unordered_*
 
@@ -7,19 +7,19 @@
 
 namespace thorin::llvm {
 
-AMDGPUCodeGen::AMDGPUCodeGen(World& world, const Cont2Config& kernel_config, int opt, bool debug)
+AMDGPUPALCodeGen::AMDGPUPALCodeGen(World& world, const Cont2Config& kernel_config, int opt, bool debug)
     : CodeGen(world, llvm::CallingConv::C, llvm::CallingConv::C, llvm::CallingConv::AMDGPU_KERNEL, opt, debug)
     , kernel_config_(kernel_config)
 {
     module().setDataLayout("e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7");
-    module().setTargetTriple("amdgcn-amd-amdhsa");
+    module().setTargetTriple("amdgcn-amd-amdpal");
 }
 
 //------------------------------------------------------------------------------
 // Kernel code
 //------------------------------------------------------------------------------
 
-void AMDGPUCodeGen::emit_fun_decl_hook(Continuation* continuation, llvm::Function* f) {
+void AMDGPUPALCodeGen::emit_fun_decl_hook(Continuation* continuation, llvm::Function* f) {
     auto config = kernel_config_.find(continuation);
     if (config != kernel_config_.end()) {
         auto block = config->second->as<GPUKernelConfig>()->block_size();
@@ -34,7 +34,7 @@ void AMDGPUCodeGen::emit_fun_decl_hook(Continuation* continuation, llvm::Functio
     }
 }
 
-llvm::Function* AMDGPUCodeGen::emit_fun_decl(Continuation* continuation) {
+llvm::Function* AMDGPUPALCodeGen::emit_fun_decl(Continuation* continuation) {
     if (continuation->name() == "llvm.amdgcn.implicitarg.ptr")
         if (auto f = defs_.lookup(entry_); f && llvm::isa<llvm::Function>(*f))
             llvm::cast<llvm::Function>(*f)->addFnAttr("amdgpu-implicitarg-ptr");
@@ -44,13 +44,13 @@ llvm::Function* AMDGPUCodeGen::emit_fun_decl(Continuation* continuation) {
     return CodeGen::emit_fun_decl(continuation);
 }
 
-llvm::Value* AMDGPUCodeGen::emit_global(const Global* global) {
+llvm::Value* AMDGPUPALCodeGen::emit_global(const Global* global) {
     if (global->is_mutable())
         world().wdef(global, "AMDGPU: Global variable '{}' will not be synced with host", global);
     return CodeGen::emit_global(global);
 }
 
-llvm::Value* AMDGPUCodeGen::emit_mathop(llvm::IRBuilder<>& irbuilder, const MathOp* mathop) {
+llvm::Value* AMDGPUPALCodeGen::emit_mathop(llvm::IRBuilder<>& irbuilder, const MathOp* mathop) {
     auto make_key = [] (MathOpTag tag, unsigned bitwidth) { return (static_cast<unsigned>(tag) << 16) | bitwidth; };
     static const std::unordered_map<unsigned, std::string> ocml_functions = {
 #define MATH_FUNCTION(name) \
@@ -84,7 +84,7 @@ llvm::Value* AMDGPUCodeGen::emit_mathop(llvm::IRBuilder<>& irbuilder, const Math
     return call_math_function(irbuilder, mathop, ocml_functions.at(key));
 }
 
-Continuation* AMDGPUCodeGen::emit_reserve(llvm::IRBuilder<>& irbuilder, const Continuation* continuation) {
+Continuation* AMDGPUPALCodeGen::emit_reserve(llvm::IRBuilder<>& irbuilder, const Continuation* continuation) {
     return emit_reserve_shared(irbuilder, continuation, true);
 }
 

--- a/src/thorin/be/llvm/amdgpu_pal.cpp
+++ b/src/thorin/be/llvm/amdgpu_pal.cpp
@@ -8,7 +8,7 @@
 namespace thorin::llvm {
 
 AMDGPUPALCodeGen::AMDGPUPALCodeGen(World& world, const Cont2Config& kernel_config, int opt, bool debug)
-    : CodeGen(world, llvm::CallingConv::C, llvm::CallingConv::C, llvm::CallingConv::AMDGPU_CS, opt, debug)
+    : CodeGen(world, llvm::CallingConv::AMDGPU_Gfx, llvm::CallingConv::C, llvm::CallingConv::AMDGPU_CS, opt, debug)
     , kernel_config_(kernel_config)
 {
     module().setDataLayout("e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7");

--- a/src/thorin/be/llvm/amdgpu_pal.cpp
+++ b/src/thorin/be/llvm/amdgpu_pal.cpp
@@ -35,12 +35,6 @@ void AMDGPUPALCodeGen::emit_fun_decl_hook(Continuation* continuation, llvm::Func
 }
 
 llvm::Function* AMDGPUPALCodeGen::emit_fun_decl(Continuation* continuation) {
-    if (continuation->name() == "llvm.amdgcn.implicitarg.ptr")
-        if (auto f = defs_.lookup(entry_); f && llvm::isa<llvm::Function>(*f))
-            llvm::cast<llvm::Function>(*f)->addFnAttr("amdgpu-implicitarg-ptr");
-    if (continuation->name() == "__ockl_printf_begin")
-        if (auto f = defs_.lookup(entry_); f && llvm::isa<llvm::Function>(*f))
-            llvm::cast<llvm::Function>(*f)->addFnAttr("amdgpu-implicitarg-num-bytes", "32");
     return CodeGen::emit_fun_decl(continuation);
 }
 

--- a/src/thorin/be/llvm/amdgpu_pal.h
+++ b/src/thorin/be/llvm/amdgpu_pal.h
@@ -1,0 +1,35 @@
+#ifndef THORIN_BE_LLVM_AMDGPU_PAL_H
+#define THORIN_BE_LLVM_AMDGPU_PAL_H
+
+#include "thorin/be/llvm/llvm.h"
+
+namespace thorin {
+
+class Load;
+
+namespace llvm {
+
+namespace llvm = ::llvm;
+
+class AMDGPUPALCodeGen : public CodeGen {
+public:
+    AMDGPUPALCodeGen(World& world, const Cont2Config&, int opt, bool debug);
+
+    const char* file_ext() const override { return ".amdgpu"; }
+
+protected:
+    void emit_fun_decl_hook(Continuation*, llvm::Function*) override;
+    llvm::Function* emit_fun_decl(Continuation*) override;
+    llvm::Value* emit_global(const Global*) override;
+    llvm::Value* emit_mathop(llvm::IRBuilder<>&, const MathOp*) override;
+    Continuation* emit_reserve(llvm::IRBuilder<>&, const Continuation*) override;
+    std::string get_alloc_name() const override { return "malloc"; }
+
+    const Cont2Config& kernel_config_;
+};
+
+}
+
+}
+
+#endif

--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -1158,7 +1158,8 @@ Continuation* CodeGen::emit_intrinsic(llvm::IRBuilder<>& irbuilder, Continuation
         case Intrinsic::CUDA:        return runtime_->emit_host_code(*this, irbuilder, Runtime::CUDA_PLATFORM,   ".cu",     continuation);
         case Intrinsic::NVVM:        return runtime_->emit_host_code(*this, irbuilder, Runtime::CUDA_PLATFORM,   ".nvvm",   continuation);
         case Intrinsic::OpenCL:      return runtime_->emit_host_code(*this, irbuilder, Runtime::OPENCL_PLATFORM, ".cl",     continuation);
-        case Intrinsic::AMDGPU:      return runtime_->emit_host_code(*this, irbuilder, Runtime::HSA_PLATFORM,    ".amdgpu", continuation);
+        case Intrinsic::AMDGPUHSA:   return runtime_->emit_host_code(*this, irbuilder, Runtime::HSA_PLATFORM,    ".amdgpu", continuation);
+        case Intrinsic::AMDGPUPAL:   return runtime_->emit_host_code(*this, irbuilder, Runtime::PAL_PLATFORM,    ".amdgpu", continuation);
         case Intrinsic::HLS:         return emit_hls(irbuilder, continuation);
         case Intrinsic::Parallel:    return emit_parallel(irbuilder, continuation);
         case Intrinsic::Fibers:      return emit_fibers(irbuilder, continuation);

--- a/src/thorin/be/llvm/runtime.h
+++ b/src/thorin/be/llvm/runtime.h
@@ -22,7 +22,8 @@ public:
         CPU_PLATFORM,
         CUDA_PLATFORM,
         OPENCL_PLATFORM,
-        HSA_PLATFORM
+        HSA_PLATFORM,
+        PAL_PLATFORM
     };
 
     /// Emits a call to anydsl_launch_kernel.

--- a/src/thorin/continuation.cpp
+++ b/src/thorin/continuation.cpp
@@ -214,7 +214,8 @@ void Continuation::set_intrinsic() {
     if      (name() == "cuda")           attributes().intrinsic = Intrinsic::CUDA;
     else if (name() == "nvvm")           attributes().intrinsic = Intrinsic::NVVM;
     else if (name() == "opencl")         attributes().intrinsic = Intrinsic::OpenCL;
-    else if (name() == "amdgpu")         attributes().intrinsic = Intrinsic::AMDGPU;
+    else if (name() == "amdgpu_hsa")     attributes().intrinsic = Intrinsic::AMDGPUHSA;
+    else if (name() == "amdgpu_pal")     attributes().intrinsic = Intrinsic::AMDGPUPAL;
     else if (name() == "hls")            attributes().intrinsic = Intrinsic::HLS;
     else if (name() == "parallel")       attributes().intrinsic = Intrinsic::Parallel;
     else if (name() == "fibers")         attributes().intrinsic = Intrinsic::Fibers;

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -90,7 +90,8 @@ enum class Intrinsic : uint8_t {
     CUDA = AcceleratorBegin,    ///< Internal CUDA-Backend.
     NVVM,                       ///< Internal NNVM-Backend.
     OpenCL,                     ///< Internal OpenCL-Backend.
-    AMDGPU,                     ///< Internal AMDGPU-Backend.
+    AMDGPUHSA,                  ///< Internal AMDGPU-HSA-Backend.
+    AMDGPUPAL,                  ///< Internal AMDGPU-PAL-Backend.
     HLS,                        ///< Internal HLS-Backend.
     Parallel,                   ///< Internal Parallel-CPU-Backend.
     Fibers,                     ///< Internal Parallel-CPU-Backend using resumable fibers.


### PR DESCRIPTION
This adds the necessary AnyDSL code generation support to execute code on AMD GPUs through the PAL driver library. This poses an alternative to the HSA (ROCm) based support for AMD GPUs currently available in AnyDSL.

Depends on PR anydsl/runtime#48 in runtime and PR (TODO) in the metaproject.