### PR TITLE
Decouple backends and intrinsics

### DIFF
--- a/src/thorin/be/codegen.cpp
+++ b/src/thorin/be/codegen.cpp
@@ -53,7 +53,7 @@ static std::unique_ptr<GPUKernelConfig> get_gpu_kernel_config(const App* app, Co
     // determine whether or not this kernel uses restrict pointers
     bool has_restrict = true;
     DefSet allocs;
-    for (size_t i = LaunchArgs::Num, e = app->num_args(); has_restrict && i != e; ++i) {
+    for (size_t i = KernelLaunchArgs::Num, e = app->num_args(); has_restrict && i != e; ++i) {
         auto arg = app->arg(i);
         if (!arg->type()->isa<PtrType>()) continue;
         auto alloc = get_alloc_call(arg);
@@ -62,7 +62,7 @@ static std::unique_ptr<GPUKernelConfig> get_gpu_kernel_config(const App* app, Co
         has_restrict &= p.second;
     }
 
-    auto it_config = app->arg(LaunchArgs::Config)->isa<Tuple>();
+    auto it_config = app->arg(KernelLaunchArgs::Config)->isa<Tuple>();
     if (it_config &&
         it_config->op(0)->isa<PrimLit>() &&
         it_config->op(1)->isa<PrimLit>() &&

--- a/src/thorin/be/codegen.cpp
+++ b/src/thorin/be/codegen.cpp
@@ -187,7 +187,7 @@ struct ShadyBackend : public Backend {
 
 struct HLSBackend : public Backend {
     explicit HLSBackend(DeviceBackends& b, World& src, std::string& hls_flags) : Backend(b, src), hls_flags_(hls_flags) {
-        b.register_intrinsic(Intrinsic::NVVM, *this, [&](const App* app, Continuation* imported) {
+        b.register_intrinsic(Intrinsic::HLS, *this, [&](const App* app, Continuation* imported) {
             HLSKernelConfig::Param2Size param_sizes;
             for (size_t i = hls_free_vars_offset, e = app->num_args(); i != e; ++i) {
                 auto arg = app->arg(i);

--- a/src/thorin/be/codegen.cpp
+++ b/src/thorin/be/codegen.cpp
@@ -1,58 +1,23 @@
 #include "thorin/be/codegen.h"
-#include "thorin/analyses/scope.h"
-#include "thorin/transform/hls_channels.h"
-#include "thorin/transform/hls_kernel_launch.h"
+
+#include "thorin/be/c/c.h"
 
 #if THORIN_ENABLE_LLVM
-#include "thorin/be/llvm/cpu.h"
 #include "thorin/be/llvm/nvvm.h"
 #include "thorin/be/llvm/amdgpu_hsa.h"
 #include "thorin/be/llvm/amdgpu_pal.h"
 #endif
+
 #if THORIN_ENABLE_SHADY
 #include "thorin/be/shady/shady.h"
 #undef empty
 #undef nodes
 #endif
-#include "thorin/be/c/c.h"
+
+#include "thorin/transform/hls_channels.h"
+#include "thorin/transform/hls_kernel_launch.h"
 
 namespace thorin {
-
-static void get_kernel_configs(
-    Thorin& thorin,
-    const std::vector<Continuation*>& kernels,
-    Cont2Config& kernel_configs,
-    std::function<std::unique_ptr<KernelConfig> (Continuation*, Continuation*)> use_callback)
-{
-    thorin.opt();
-
-    auto externals = thorin.world().externals();
-    for (auto continuation : kernels) {
-        // recover the imported continuation (lost after the call to opt)
-        Continuation* imported = nullptr;
-        for (auto [_, def] : externals) {
-            auto exported = def->isa<Continuation>();
-            if (!exported) continue;
-            if (!exported->has_body()) continue;
-            if (exported->name() == continuation->name())
-                imported = exported;
-        }
-        if (!imported) continue;
-
-        visit_uses(continuation, [&] (Continuation* use) {
-            assert(use->has_body());
-            auto config = use_callback(use, imported);
-            if (config) {
-                auto p = kernel_configs.emplace(imported, std::move(config));
-                assert_unused(p.second && "single kernel config entry expected");
-            }
-            return false;
-        }, true);
-
-        continuation->world().make_external(continuation);
-        continuation->destroy("codegen");
-    }
-}
 
 static const App* get_alloc_call(const Def* def) {
     // look through casts
@@ -84,95 +49,104 @@ static uint64_t get_alloc_size(const Def* def) {
     return size ? static_cast<uint64_t>(size->value().get_qu64()) : 0_u64;
 }
 
-DeviceBackends::DeviceBackends(World& world, int opt, bool debug, std::string& flags)
-    : cgs {}
-{
-    std::vector<Importer> importers;
-    for (auto& name : backend_names) {
-        accelerator_code.emplace_back(name);
-        importers.emplace_back(world, accelerator_code.back().world());
+static std::unique_ptr<GPUKernelConfig> get_gpu_kernel_config(const App* app, Continuation* imported) {
+    // determine whether or not this kernel uses restrict pointers
+    bool has_restrict = true;
+    DefSet allocs;
+    for (size_t i = LaunchArgs::Num, e = app->num_args(); has_restrict && i != e; ++i) {
+        auto arg = app->arg(i);
+        if (!arg->type()->isa<PtrType>()) continue;
+        auto alloc = get_alloc_call(arg);
+        if (!alloc) has_restrict = false;
+        auto p = allocs.insert(alloc);
+        has_restrict &= p.second;
     }
 
-    static const auto backend_intrinsics = std::array {
-        std::pair { CUDA,       Intrinsic::CUDA         },
-        std::pair { NVVM,       Intrinsic::NVVM         },
-        std::pair { OpenCL,     Intrinsic::OpenCL       },
-        std::pair { AMDGPU_HSA, Intrinsic::AMDGPUHSA    },
-        std::pair { AMDGPU_PAL, Intrinsic::AMDGPUPAL    },
-        std::pair { HLS,        Intrinsic::HLS          },
-        std::pair { Shady,      Intrinsic::ShadyCompute }
-    };
+    auto it_config = app->arg(LaunchArgs::Config)->isa<Tuple>();
+    if (it_config &&
+        it_config->op(0)->isa<PrimLit>() &&
+        it_config->op(1)->isa<PrimLit>() &&
+        it_config->op(2)->isa<PrimLit>()) {
+        return std::make_unique<GPUKernelConfig>(std::tuple<int, int, int>{
+                it_config->op(0)->as<PrimLit>()->qu32_value().data(),
+                it_config->op(1)->as<PrimLit>()->qu32_value().data(),
+                it_config->op(2)->as<PrimLit>()->qu32_value().data()
+        }, has_restrict);
+    }
+    return std::make_unique<GPUKernelConfig>(std::tuple<int, int, int>{-1, -1, -1}, has_restrict);
+}
 
-    // determine different parts of the world which need to be compiled differently
-    ScopesForest(world).for_each([&] (const Scope& scope) {
-        auto continuation = scope.entry();
-        Continuation* imported = nullptr;
-        for (auto [backend, intrinsic] : backend_intrinsics) {
-            if (is_passed_to_intrinsic(continuation, intrinsic)) {
-                imported = importers[backend].import(continuation)->as_nom<Continuation>();
-                break;
-            }
-        }
+Backend::Backend(thorin::DeviceBackends& backends, World& src) : backends_(backends), device_code_(src), importer_(std::make_unique<Importer>(src, device_code_.world())) {}
 
-        if (imported == nullptr)
-            return;
-
-        // Necessary so that the names match in the original and imported worlds
-        imported->set_name(continuation->unique_name());
-        continuation->set_name(continuation->unique_name());
-        for (size_t i = 0, e = continuation->num_params(); i != e; ++i)
-            imported->param(i)->set_name(continuation->param(i)->name());
-        imported->world().make_external(imported);
-        imported->attributes().cc = CC::C;
-
-        kernels.emplace_back(continuation);
-    });
-
-    for (auto [backend, intrinsic] : backend_intrinsics) {
-        if (backend == HLS)
-            continue;
-
-        if (!accelerator_code[backend].world().empty()) {
-            get_kernel_configs(accelerator_code[backend], kernels, kernel_config, [&](Continuation *use, Continuation * /* imported */) {
-                auto app = use->body();
-                if (app->callee()->as<Continuation>()->intrinsic() != intrinsic)
-                    return std::unique_ptr<GPUKernelConfig>(nullptr);
-                // determine whether or not this kernel uses restrict pointers
-                bool has_restrict = true;
-                DefSet allocs;
-                for (size_t i = LaunchArgs::Num, e = app->num_args(); has_restrict && i != e; ++i) {
-                    auto arg = app->arg(i);
-                    if (!arg->type()->isa<PtrType>()) continue;
-                    auto alloc = get_alloc_call(arg);
-                    if (!alloc) has_restrict = false;
-                    auto p = allocs.insert(alloc);
-                    has_restrict &= p.second;
-                }
-
-                auto it_config = app->arg(LaunchArgs::Config)->isa<Tuple>();
-                if (it_config &&
-                    it_config->op(0)->isa<PrimLit>() &&
-                    it_config->op(1)->isa<PrimLit>() &&
-                    it_config->op(2)->isa<PrimLit>()) {
-                    return std::make_unique<GPUKernelConfig>(std::tuple<int, int, int>{
-                        it_config->op(0)->as<PrimLit>()->qu32_value().data(),
-                        it_config->op(1)->as<PrimLit>()->qu32_value().data(),
-                        it_config->op(2)->as<PrimLit>()->qu32_value().data()
-                    }, has_restrict);
-                }
-                return std::make_unique<GPUKernelConfig>(std::tuple<int, int, int>{-1, -1, -1}, has_restrict);
-            });
-        }
+struct CudaBackend : public Backend {
+    explicit CudaBackend(DeviceBackends& b, World& src) : Backend(b, src) {
+        b.register_intrinsic(Intrinsic::CUDA, *this, get_gpu_kernel_config);
     }
 
-    // get the HLS kernel configurations
-    Top2Kernel top2kernel;
-    DeviceParams hls_host_params;
-    if (!accelerator_code[HLS].world().empty()) {
-        hls_host_params = hls_channels(accelerator_code[HLS], importers[HLS], top2kernel, world);
+    std::unique_ptr<CodeGen> create_cg(const Cont2Config& config) override {
+        std::string empty;
+        return std::make_unique<c::CodeGen>(device_code_, config, c::Lang::CUDA, backends_.debug(), empty);
+    }
+};
 
-        get_kernel_configs(accelerator_code[HLS], kernels, kernel_config, [&] (Continuation* use, Continuation* imported) {
-            auto app = use->body();
+struct OpenCLBackend : public Backend {
+    explicit OpenCLBackend(DeviceBackends& b, World& src) : Backend(b, src) {
+        b.register_intrinsic(Intrinsic::OpenCL, *this, get_gpu_kernel_config);
+    }
+
+    std::unique_ptr<CodeGen> create_cg(const Cont2Config& config) override {
+        std::string empty;
+        return std::make_unique<c::CodeGen>(device_code_, config, c::Lang::OpenCL, backends_.debug(), empty);
+    }
+};
+
+#if THORIN_ENABLE_LLVM
+struct AMDHSABackend : public Backend {
+    explicit AMDHSABackend(DeviceBackends& b, World& src) : Backend(b, src) {
+        b.register_intrinsic(Intrinsic::AMDGPUHSA, *this, get_gpu_kernel_config);
+    }
+
+    std::unique_ptr<CodeGen> create_cg(const Cont2Config& config) override {
+        return std::make_unique<llvm::AMDGPUHSACodeGen>(device_code_, config, backends_.opt(), backends_.debug());
+    }
+};
+
+struct AMDPALBackend : public Backend {
+    explicit AMDPALBackend(DeviceBackends& b, World& src) : Backend(b, src) {
+        b.register_intrinsic(Intrinsic::AMDGPUPAL, *this, get_gpu_kernel_config);
+    }
+
+    std::unique_ptr<CodeGen> create_cg(const Cont2Config& config) override {
+        return std::make_unique<llvm::AMDGPUPALCodeGen>(device_code_, config, backends_.opt(), backends_.debug());
+    }
+};
+
+struct NVVMBackend : public Backend {
+    explicit NVVMBackend(DeviceBackends& b, World& src) : Backend(b, src) {
+        b.register_intrinsic(Intrinsic::NVVM, *this, get_gpu_kernel_config);
+    }
+
+    std::unique_ptr<CodeGen> create_cg(const Cont2Config& config) override {
+        return std::make_unique<llvm::NVVMCodeGen>(device_code_, config, backends_.opt(), backends_.debug());
+    }
+};
+#endif
+
+#if THORIN_ENABLE_SHADY
+struct ShadyBackend : public Backend {
+    explicit ShadyBackend(DeviceBackends2& b, World& src) : Backend(b, src) {
+        b.register_intrinsic(Intrinsic::ShadyCompute, get_gpu_kernel_config);
+    }
+
+    std::unique_ptr<CodeGen> create_cg(const Cont2Config& config) override {
+        return std::make_unique<shady_be::CodeGen>(device_code_, config, backends_.debug());
+    }
+};
+#endif
+
+struct HLSBackend : public Backend {
+    explicit HLSBackend(DeviceBackends& b, World& src, std::string& hls_flags) : Backend(b, src), hls_flags_(hls_flags) {
+        b.register_intrinsic(Intrinsic::NVVM, *this, [&](const App* app, Continuation* imported) {
             HLSKernelConfig::Param2Size param_sizes;
             for (size_t i = hls_free_vars_offset, e = app->num_args(); i != e; ++i) {
                 auto arg = app->arg(i);
@@ -180,7 +154,7 @@ DeviceBackends::DeviceBackends(World& world, int opt, bool debug, std::string& f
                 if (!ptr_type) continue;
                 auto size = get_alloc_size(arg);
                 if (size == 0)
-                    world.edef(arg, "array size is not known at compile time");
+                    b.world().edef(arg, "array size is not known at compile time");
                 auto elem_type = ptr_type->pointee();
                 size_t multiplier = 1;
                 if (!elem_type->isa<PrimType>()) {
@@ -195,29 +169,137 @@ DeviceBackends::DeviceBackends(World& world, int opt, bool debug, std::string& f
                 }
                 auto prim_type = elem_type->isa<PrimType>();
                 if (!prim_type)
-                    world.edef(arg, "only pointers to arrays of primitive types are supported");
+                    b.world().edef(arg, "only pointers to arrays of primitive types are supported");
                 auto num_elems = size / (multiplier * num_bits(prim_type->primtype_tag()) / 8);
                 // imported has type: fn (mem, fn (mem), ...)
                 param_sizes.emplace(imported->param(i - hls_free_vars_offset + 2), num_elems);
             }
             return std::make_unique<HLSKernelConfig>(param_sizes);
         });
-        hls_annotate_top(accelerator_code[HLS].world(), top2kernel, kernel_config);
     }
-    hls_kernel_launch(world, hls_host_params);
 
+    std::unique_ptr<CodeGen> create_cg(const Cont2Config& config) override {
+        Top2Kernel top2kernel;
+        DeviceParams hls_host_params;
+
+        hls_host_params = hls_channels(device_code_, *importer_, top2kernel, backends_.world());
+        hls_annotate_top(device_code_.world(), top2kernel, const_cast<Cont2Config&>(config));
+        hls_kernel_launch(device_code_.world(), hls_host_params);
+
+        return std::make_unique<c::CodeGen>(device_code_, config, c::Lang::HLS, backends_.debug(), hls_flags_);
+    }
+
+    std::string& hls_flags_;
+};
+
+DeviceBackends::DeviceBackends(thorin::World& world, int opt, bool debug, std::string& hls_flags) : world_(world), opt_(opt), debug_(debug) {
+    register_backend(std::make_unique<CudaBackend>(*this, world));
+    register_backend(std::make_unique<OpenCLBackend>(*this, world));
 #if THORIN_ENABLE_LLVM
-    if (!accelerator_code[NVVM      ].world().empty()) cgs[NVVM      ] = std::make_unique<llvm::NVVMCodeGen     >(accelerator_code[NVVM      ], kernel_config, opt, debug);
-    if (!accelerator_code[AMDGPU_HSA].world().empty()) cgs[AMDGPU_HSA] = std::make_unique<llvm::AMDGPUHSACodeGen>(accelerator_code[AMDGPU_HSA], kernel_config, opt, debug);
-    if (!accelerator_code[AMDGPU_PAL].world().empty()) cgs[AMDGPU_PAL] = std::make_unique<llvm::AMDGPUPALCodeGen>(accelerator_code[AMDGPU_PAL], kernel_config, opt, debug);
-#else
-    (void)opt;
+    register_backend(std::make_unique<AMDHSABackend>(*this, world));
+    register_backend(std::make_unique<AMDPALBackend>(*this, world));
+    register_backend(std::make_unique<NVVMBackend>(*this, world));
 #endif
 #if THORIN_ENABLE_SHADY
-    if (!accelerator_code[Shady].world().empty()) cgs[Shady] = std::make_unique<shady_be::CodeGen>(accelerator_code[Shady], kernel_config, debug);
+    register_backend(std::make_unique<ShadyBackend>(*this, world))
 #endif
-    for (auto [backend, lang] : std::array { std::pair { CUDA, c::Lang::CUDA }, std::pair { OpenCL, c::Lang::OpenCL }, std::pair { HLS, c::Lang::HLS } })
-        if (!accelerator_code[backend].world().empty()) cgs[backend] = std::make_unique<c::CodeGen>(accelerator_code[backend], kernel_config, lang, debug, flags);
+    register_backend(std::make_unique<HLSBackend>(*this, world, hls_flags));
+
+    search_for_device_code();
+}
+
+void DeviceBackends::register_backend(std::unique_ptr<Backend> backend) {
+    backends_.push_back(std::move(backend));
+}
+
+World& DeviceBackends::world() { return world_; }
+bool DeviceBackends::debug() { return debug_; }
+int DeviceBackends::opt() { return opt_; }
+
+void DeviceBackends::register_intrinsic(thorin::Intrinsic intrinsic, Backend& backend, GetKernelConfigFn f) {
+    intrinsics_[intrinsic] = std::make_pair(&backend, f);
+}
+
+void DeviceBackends::search_for_device_code() {
+    // determine different parts of the world which need to be compiled differently
+    ScopesForest(world_).for_each([&] (const Scope& scope) {
+        auto continuation = scope.entry();
+        Continuation* imported = nullptr;
+
+        Intrinsic intrinsic = Intrinsic::None;
+        visit_capturing_intrinsics(continuation, [&] (Continuation* continuation) {
+            if (continuation->is_accelerator()) {
+                intrinsic = continuation->intrinsic();
+                return true;
+            }
+            return false;
+        });
+
+        if (intrinsic == Intrinsic::None)
+            return;
+
+        auto handler = intrinsics_.find(intrinsic);
+        assert(handler != intrinsics_.end());
+        auto [backend, get_config] = handler->second;
+
+        imported = backend->importer_->import(continuation)->as_nom<Continuation>();
+        if (imported == nullptr)
+            return;
+
+        // Necessary so that the names match in the original and imported worlds
+        imported->set_name(continuation->unique_name());
+        continuation->set_name(continuation->unique_name());
+        for (size_t i = 0, e = continuation->num_params(); i != e; ++i)
+            imported->param(i)->set_name(continuation->param(i)->name());
+        imported->world().make_external(imported);
+        imported->attributes().cc = CC::C;
+
+        backend->kernels_.emplace_back(continuation);
+    });
+
+    for (auto& backend : backends_) {
+        if (backend->thorin().world().empty())
+            continue;
+
+        backend->thorin().opt();
+
+        Cont2Config kernel_configs;
+
+        auto externals = world_.externals();
+        for (auto continuation : backend->kernels_) {
+            // recover the imported continuation (lost after the call to opt)
+            Continuation* imported = nullptr;
+            for (auto [_, def] : externals) {
+                auto exported = def->isa<Continuation>();
+                if (!exported) continue;
+                if (!exported->has_body()) continue;
+                if (exported->name() == continuation->name())
+                    imported = exported;
+            }
+            if (!imported) continue;
+
+            visit_uses(continuation, [&] (Continuation* use) {
+                assert(use->has_body());
+
+                auto handler = intrinsics_.find(use->body()->callee()->as<Continuation>()->intrinsic());
+                assert(handler != intrinsics_.end());
+                auto [backend2, get_config] = handler->second;
+                assert(backend2 == &*backend);
+
+                auto config = get_config(use->body(), imported);
+                if (config) {
+                    auto p = kernel_configs.emplace(imported, std::move(config));
+                    assert_unused(p.second && "single kernel config entry expected");
+                }
+                return false;
+            }, true);
+
+            continuation->world().make_external(continuation);
+            continuation->destroy("codegen");
+        }
+
+        cgs.emplace_back(backend->create_cg(kernel_configs));
+    }
 }
 
 CodeGen::CodeGen(Thorin& thorin, bool debug)

--- a/src/thorin/be/codegen.h
+++ b/src/thorin/be/codegen.h
@@ -39,17 +39,47 @@ struct LaunchArgs {
     };
 };
 
+struct DeviceBackends;
+
+struct Backend {
+    Backend(DeviceBackends& backends, World& src);
+
+    virtual std::unique_ptr<CodeGen> create_cg(const Cont2Config& config) = 0;
+
+    Thorin& thorin() { return device_code_; }
+    Importer& importer() { return *importer_; }
+
+protected:
+    DeviceBackends& backends_;
+    Thorin device_code_;
+    std::unique_ptr<Importer> importer_;
+
+    std::vector<Continuation*> kernels_;
+    friend DeviceBackends;
+};
+
 struct DeviceBackends {
     DeviceBackends(World& world, int opt, bool debug, std::string& hls_flags);
 
-    Cont2Config kernel_config;
-    std::vector<Continuation*> kernels;
+    World& world();
+    std::vector<std::unique_ptr<CodeGen>> cgs;
 
-    enum { CUDA, NVVM, OpenCL, AMDGPU_HSA, AMDGPU_PAL, HLS, Shady, BackendCount };
-    std::array<std::unique_ptr<CodeGen>, BackendCount> cgs;
+    int opt();
+    bool debug();
+
+    void register_backend(std::unique_ptr<Backend>);
+    using GetKernelConfigFn = std::function<std::unique_ptr<KernelConfig>(const App*, Continuation*)>;
+    void register_intrinsic(Intrinsic, Backend&, GetKernelConfigFn);
+
 private:
-    std::array<const char*, BackendCount> backend_names = { "CUDA", "NVVM", "OpenCL", "AMDGPU_HSA", "AMDGPU_PAL", "HLS", "Shady" };
-    std::vector<Thorin> accelerator_code;
+    World& world_;
+    std::vector<std::unique_ptr<Backend>> backends_;
+    std::unordered_map<Intrinsic, std::pair<Backend*, GetKernelConfigFn>> intrinsics_;
+
+    int opt_;
+    bool debug_;
+
+    void search_for_device_code();
 };
 
 }

--- a/src/thorin/be/codegen.h
+++ b/src/thorin/be/codegen.h
@@ -27,18 +27,6 @@ private:
     bool debug_;
 };
 
-struct LaunchArgs {
-    enum {
-        Mem = 0,
-        Device,
-        Space,
-        Config,
-        Body,
-        Return,
-        Num
-    };
-};
-
 struct DeviceBackends;
 
 struct Backend {

--- a/src/thorin/be/codegen.h
+++ b/src/thorin/be/codegen.h
@@ -32,6 +32,7 @@ struct DeviceBackends;
 struct Backend {
     Backend(DeviceBackends& backends, World& src);
 
+    std::unique_ptr<Cont2Config> get_kernel_configs();
     virtual std::unique_ptr<CodeGen> create_cg(const Cont2Config& config) = 0;
 
     Thorin& thorin() { return device_code_; }
@@ -68,6 +69,7 @@ private:
     bool debug_;
 
     void search_for_device_code();
+friend Backend;
 };
 
 }

--- a/src/thorin/be/kernel_config.h
+++ b/src/thorin/be/kernel_config.h
@@ -6,6 +6,18 @@
 
 namespace thorin {
 
+struct KernelLaunchArgs {
+    enum {
+        Mem = 0,
+        Device,
+        Space,
+        Config,
+        Body,
+        Return,
+        Num
+    };
+};
+
 class KernelConfig : public RuntimeCast<KernelConfig> {
 public:
     virtual ~KernelConfig() {}

--- a/src/thorin/be/llvm/runtime.cpp
+++ b/src/thorin/be/llvm/runtime.cpp
@@ -67,22 +67,22 @@ void Runtime::emit_host_code(CodeGen& code_gen, llvm::IRBuilder<>& builder, Plat
     // target(mem, device, (dim.x, dim.y, dim.z), (block.x, block.y, block.z), body, return, free_vars)
     auto target = body->callee()->as_nom<Continuation>();
     assert_unused(target->is_intrinsic());
-    assert(body->num_args() >= LaunchArgs::Num && "required arguments are missing");
+    assert(body->num_args() >= KernelLaunchArgs::Num && "required arguments are missing");
 
     // arguments
-    auto target_device_id = code_gen.emit(body->arg(LaunchArgs::Device));
+    auto target_device_id = code_gen.emit(body->arg(KernelLaunchArgs::Device));
     auto target_platform = builder.getInt32(platform);
     auto target_device = builder.CreateOr(target_platform, builder.CreateShl(target_device_id, builder.getInt32(4)));
 
-    auto it_space = body->arg(LaunchArgs::Space);
-    auto it_config = body->arg(LaunchArgs::Config);
-    auto kernel = body->arg(LaunchArgs::Body)->as<Global>()->init()->as<Continuation>();
+    auto it_space = body->arg(KernelLaunchArgs::Space);
+    auto it_config = body->arg(KernelLaunchArgs::Config);
+    auto kernel = body->arg(KernelLaunchArgs::Body)->as<Global>()->init()->as<Continuation>();
 
     auto& world = continuation->world();
     //auto kernel_name = builder.CreateGlobalStringPtr(kernel->name() == "hls_top" ? kernel->name() : kernel->name());
     auto kernel_name = builder.CreateGlobalStringPtr(kernel->name());
     auto file_name = builder.CreateGlobalStringPtr(world.name() + ext);
-    const size_t num_kernel_args = body->num_args() - LaunchArgs::Num;
+    const size_t num_kernel_args = body->num_args() - KernelLaunchArgs::Num;
 
     // allocate argument pointers, sizes, and types
     llvm::Value* args   = code_gen.emit_alloca(builder, llvm::ArrayType::get(builder.getInt8PtrTy(), num_kernel_args), "args");
@@ -93,7 +93,7 @@ void Runtime::emit_host_code(CodeGen& code_gen, llvm::IRBuilder<>& builder, Plat
 
     // fill array of arguments
     for (size_t i = 0; i < num_kernel_args; ++i) {
-        auto target_arg = body->arg(i + LaunchArgs::Num);
+        auto target_arg = body->arg(i + KernelLaunchArgs::Num);
         const auto target_val = code_gen.emit(target_arg);
 
         KernelArgType arg_type;

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1299,6 +1299,8 @@ Thorin::Thorin(const std::string& name)
     : world_(std::make_unique<World>(name))
 {}
 
+Thorin::Thorin(thorin::World& src) : world_(std::make_unique<World>(src)) {}
+
 void Thorin::opt() {
     bool debug_passes = getenv("THORIN_DEBUG_PASSES");
 #define RUN_PASS(pass) \

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -405,6 +405,7 @@ class Thorin {
 public:
     /// Initial world constructor
     explicit Thorin(const std::string& name);
+    explicit Thorin(World& src);
 
     World& world() { return *world_; };
     std::unique_ptr<World>& world_container() { return world_; }


### PR DESCRIPTION
Our code offloading code in `DeviceBackends` is a messy class with a bunch of tightly-coupled, poorly documented logic.
This PR factors out a `Backend` class, and rewrites `DeviceBackends` to take advantage of such:

* `Backend`s  now hold a world containing device code.
* Backends can register any number of intrinsics to themselves, and when they do so they also provide a function to extract a `KernelConfig` from call sites to that intrinsic.
  * This also removes the 1:1 correspondence between intrinsics and backends, and allows backends to have various entry points, with potentially different calling launch arguments.
* Finally, backends are in charge of creating the final code generator. Before they do so, they also get a chance to run some passes on the device code.

The HLS backend had a bunch of ad-hoc logic that was implemented by copy/pasting the logic for the older targets, all in `DeviceBackends`. This code has been moved to `HLSBackend` and the HLS-specific passes run as part of `HLSBackend::create_cg`.

The interface of `DeviceBackends` is unchanged.