### PR TITLE
Fix memory leak when deleting a World

### DIFF
--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -147,7 +147,6 @@ public:
 
 private:
     Continuation(World&, const FnType* pi, const Attributes& attributes, Debug dbg);
-    virtual ~Continuation() { for (auto param : params()) delete param; }
 
 public:
     const FnType* type() const { return Def::type()->as<FnType>(); }

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1291,6 +1291,12 @@ const Def* World::cse_base(const Def* def) {
     return def;
 }
 
+World::~World() {
+    for (const Def* def : data_.defs_) {
+        delete def;
+    }
+}
+
 /*
  * optimizations
  */

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -79,6 +79,8 @@ public:
         state_  = other.state_;
     }
 
+    ~World();
+
     /// @name manage global identifier - a unique number for each Def
     //@{
     //u32 cur_gid() const { return state_.cur_gid; }


### PR DESCRIPTION
At some point we seem to have messed up the cleanup of the Sea of nodes, this PR should fix it.

Tested successfully on all Artic tests so far, working on other MM fixes, working on Rodent testing.