### PR TITLE
Make it explicit which parameter is the return address

### DIFF
--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -141,29 +141,28 @@ llvm::Type* CodeGen::convert(const Type* type) {
         case Node_ClosureType:
         case Node_FnType: {
             // extract "return" type, collect all other types
-            auto fn = type->as<FnType>();
-            llvm::Type* ret = nullptr;
+            auto tfn_type = type->as<FnType>();
+            llvm::Type* ret = llvm::Type::getVoidTy(context()); // top-level non-returning continuations should be void
             std::vector<llvm::Type*> ops;
-            for (auto op : fn->types()) {
+            for (auto op : tfn_type->domain()) {
                 if (op->isa<MemType>() || op == world().unit_type()) continue;
-                auto fn = op->isa<FnType>();
-                if (fn && !op->isa<ClosureType>()) {
-                    assert(!ret && "only one 'return' supported");
-                    std::vector<llvm::Type*> ret_types;
-                    for (auto fn_op : fn->types()) {
-                        if (fn_op->isa<MemType>() || fn_op == world().unit_type()) continue;
-                        ret_types.push_back(convert(fn_op));
-                    }
-                    if (ret_types.size() == 0)      ret = llvm::Type::getVoidTy(context());
-                    else if (ret_types.size() == 1) ret = ret_types.back();
-                    else                            ret = llvm::StructType::get(context(), ret_types);
-                } else
-                    ops.push_back(convert(op));
+                ops.push_back(convert(op));
             }
 
-            if (!ret) {
-                ret = llvm::Type::getVoidTy(context());
+            if (tfn_type->is_returning()) {
+                auto ret_ty = tfn_type->return_param_type();
+                assert(ret_ty);
+                std::vector<llvm::Type*> ret_types;
+                for (auto fn_op : ret_ty->types()) {
+                    if (fn_op->isa<MemType>() || fn_op == world().unit_type()) continue;
+                    ret_types.push_back(convert(fn_op));
+                }
+                if (ret_types.size() == 0)      ret = llvm::Type::getVoidTy(context());
+                else if (ret_types.size() == 1) ret = ret_types.back();
+                else                            ret = llvm::StructType::get(context(), ret_types);
             }
+
+            assert(ret);
 
             if (type->tag() == Node_FnType) {
                 auto llvm_type = llvm::FunctionType::get(ret, ops, false);
@@ -171,9 +170,16 @@ llvm::Type* CodeGen::convert(const Type* type) {
             }
 
             auto env_type = convert(Closure::environment_type(world()));
-            auto ptr_type = llvm::PointerType::get(context(), 0);
+            ops.push_back(env_type);
+            auto fn_type = llvm::FunctionType::get(ret, ops, false);
+            auto ptr_type = llvm::PointerType::get(fn_type, 0);
             llvm_type = llvm::StructType::get(context(), { ptr_type, env_type });
             return types_[type] = llvm_type;
+        }
+        case Node_ReturnType: {
+            auto ret_t = type->as<ReturnType>();
+            auto tuple_t = world().tuple_type({ ret_t->mangle_for_codegen(), world().definite_array_type(world().type_qu8(), 200) });
+            return types_[type] = convert(world().ptr_type(tuple_t));
         }
 
         case Node_StructType: {
@@ -427,6 +433,9 @@ llvm::Function* CodeGen::prepare(const Scope& scope) {
         discope_ = disub_program;
     }
 
+    has_alloca_ = false;
+    potential_tailcalls_.clear();
+
     return fct;
 }
 
@@ -478,6 +487,10 @@ void CodeGen::finalize(const Scope&) {
         if (auto variant = def->isa<Variant>(); variant && !variant->value()->has_dep(Dep::Param))
             to_remove.push_back(def);
     }
+    if (!has_alloca_) for (auto call : potential_tailcalls_) {
+        call->setTailCall(true);
+        // call->setTailCallKind(llvm::CallInst::TCK_MustTail);
+    }
     for (auto& def : to_remove)
         defs_.erase(def);
 }
@@ -522,13 +535,15 @@ llvm::CallInst* CodeGen::emit_call(llvm::IRBuilder<>& irbuilder, const Def* call
             }
         }
         return nullptr;
+    } else if (auto return_point = callee->isa<ReturnPoint>()) { // for direct-style calls, just forward to the destination
+        return emit_call(irbuilder, return_point->continuation(), args);
     } else if (callee->isa<Bottom>()) {
         irbuilder.CreateUnreachable();
         return nullptr;
     } else if (auto cont = callee->isa_nom<Continuation>(); cont && scope_->contains(cont) && cont != entry_) {
         assert(cont->is_basicblock());
         size_t j = 0, i = 0;
-        for (auto t: cont->type()->types()) {
+        for (auto t: cont->type()->domain()) {
             i++;
             assert(t->order() == 0);
             if (t->isa<MemType>() || t == world().unit_type())
@@ -601,7 +616,7 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
         }
     } else if (auto callee = body->callee()->isa_nom<Continuation>(); callee && callee->is_intrinsic()) {
         auto args = emit_intrinsic(irbuilder, continuation);
-        call_instr = emit_call(irbuilder, body->arg(callee->ret_param()->index()), args);
+        call_instr = emit_call(irbuilder, body->arg(callee->type()->ret_param_index()), args);
     } else {
         // plain continuation call: we can just emit all the arguments
         std::vector<llvm::Value*> args;
@@ -617,11 +632,11 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
         }
 
         call_instr = emit_call(irbuilder, body->callee(), args);
-        if (body->callee()->type()->as<FnType>()->is_returning() && !body->callee()->isa<Bottom>()) {
+        if (auto codom = body->callee()->type()->as<FnType>()->codomain()) {
             assert(call_instr && "returning calls always involve one of those");
             assert(ret_arg && "we need a return argument too!");
 
-            auto ret_args = split_values(irbuilder, ret_arg->type()->as<FnType>()->types(), call_instr);
+            auto ret_args = split_values(irbuilder, *codom, call_instr);
             call_instr = emit_call(irbuilder, ret_arg, ret_args);
         }
     }
@@ -629,7 +644,7 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
     if (call_instr) {
         // we need to add a dummy return terminator if the last instruction is a call
         if (entry_->type()->is_returning()) {
-            auto entry_return_t = mangle_for_codegen(world(), entry_->ret_param()->type()->as<FnType>()->types());
+            auto entry_return_t = entry_->type()->return_param_type()->mangle_for_codegen();
             if (entry_return_t != world().unit_type()) {
                 irbuilder.CreateRet(llvm::UndefValue::get(convert(entry_return_t)));
             } else
@@ -1071,6 +1086,7 @@ llvm::AllocaInst* CodeGen::emit_alloca(llvm::IRBuilder<>& irbuilder, llvm::Type*
     else
         alloca = new llvm::AllocaInst(type, layout.getAllocaAddrSpace(), nullptr, name, entry->getFirstNonPHIOrDbg());
     alloca->setAlignment(layout.getABITypeAlign(type));
+    has_alloca_ = true;
     return alloca;
 }
 
@@ -1429,10 +1445,10 @@ llvm::Value* CodeGen::emit_reserve_shared(llvm::IRBuilder<>& irbuilder, const Co
     if (!body->arg(1)->isa<PrimLit>())
         world().edef(body->arg(1), "reserve_shared: couldn't extract memory size");
     auto num_elems = body->arg(1)->as<PrimLit>()->ps32_value();
-    auto cont = body->arg(2)->as_nom<Continuation>();
-    auto type = convert(cont->param(1)->type());
+    auto cont_t = body->arg(2)->type()->as<FnType>();
+    auto type = convert(cont_t->domain()[1]);
     // construct array type
-    auto elem_type = cont->param(1)->type()->as<PtrType>()->pointee()->as<ArrayType>()->elem_type();
+    auto elem_type = cont_t->domain()[1]->as<PtrType>()->pointee()->as<ArrayType>()->elem_type();
     auto smem_type = this->convert(continuation->world().definite_array_type(elem_type, num_elems));
     auto name = continuation->unique_name();
     // NVVM doesn't allow '.' in global identifier

--- a/src/thorin/be/llvm/llvm.h
+++ b/src/thorin/be/llvm/llvm.h
@@ -137,6 +137,8 @@ protected:
     llvm::CallingConv::ID kernel_calling_convention_;
     llvm::DIScope* discope_ = nullptr;
     std::unique_ptr<Runtime> runtime_;
+    bool has_alloca_;
+    std::vector<llvm::CallInst*> potential_tailcalls_;
 #if THORIN_ENABLE_RV
     std::vector<std::tuple<u32, llvm::Function*, llvm::CallInst*>> vec_todo_;
 #endif

--- a/src/thorin/be/spirv/spirv.cpp
+++ b/src/thorin/be/spirv/spirv.cpp
@@ -218,15 +218,9 @@ static bool is_return_block(thorin::Continuation* cont) {
     for (auto use : cont->copy_uses()) {
         if (use.def()->isa<Param>())
             continue; // the block can have params
-        else if (auto app = use.def()->isa<App>()) {
-            if (auto callee = app->callee()->isa_nom<Continuation>()) {
-                auto arg_index = use.index() - App::FirstArg;
-                auto ret_param = callee->ret_param();
-                if (ret_param && arg_index == ret_param->index()) {
-                    uses_as_ret_param++;
-                    continue;
-                }
-            }
+        if (use.def()->isa<ReturnPoint>()) {
+            uses_as_ret_param++;
+            continue; // the block can be returned to (once)
         }
         return false; // any other use disqualifies the block
     }
@@ -336,15 +330,19 @@ Id CodeGen::emit_as_bb(thorin::Continuation* cont) {
     return cont2bb_[cont]->label;
 }
 
-void CodeGen::emit_epilogue(Continuation* continuation) {
-    if (!continuation->has_body())
-        return;
+void CodeGen::emit_jump(BasicBlockBuilder* bb, const Def* to, std::vector<Id> args) {
+    if (auto ret_point = to->isa<ReturnPoint>()) {
+        to = ret_point->continuation();
+    }
 
-    BasicBlockBuilder* bb = cont2bb_[continuation];
-
-    // Handles the potential nuances of jumping to another continuation
-    auto jump_to_next_cont_with_args = [&](Continuation* succ, std::vector<Id> args) {
-        assert(succ->is_basicblock());
+    if (to == entry_->ret_param()) {
+        switch (args.size()) {
+            case 0:  bb->terminator.return_void(); break;
+            case 1:  bb->terminator.return_value(args[0]); break;
+            default: bb->terminator.return_value(emit_composite(bb, builder_->current_fn_->fn_ret_type, args));
+        }
+    } else if (auto succ = to->isa_nom<Continuation>(); succ && scope_->contains(succ)) {
+        // local BB jump
         BasicBlockBuilder* dstbb = cont2bb_[succ];
 
         for (size_t i = 0, j = 0; i != succ->num_params(); ++i) {
@@ -359,48 +357,37 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
                 defs_[param] = args[j];
             } else {
                 auto& phi = cont2bb_[succ]->phis_map[param];
-                phi.preds.emplace_back(args[j], emit_as_bb(continuation));
+                phi.preds.emplace_back(args[j], bb->label);
             }
             j++;
         }
         bb->terminator.branch(emit(succ));
-    };
+    }
+}
 
+void CodeGen::emit_epilogue(Continuation* continuation) {
+    if (!continuation->has_body())
+        return;
+
+    BasicBlockBuilder* bb = cont2bb_[continuation];
     auto& app = *continuation->body();
 
-    if (app.callee() == entry_->ret_param()) {
-        std::vector<Id> values;
-
+    // calls to intrinsics involve passing basic blocks, which aren't first-class values
+    // however this isn't encoded in their type (fn[...]), and establishing whether they are is hard
+    // instead we can just lazily emit the arguments and deal with the special-case control-flow intrinsics first
+    auto emit_args = [&]() {
+        std::vector<Id> args;
         for (auto arg : app.args()) {
-            assert(arg->order() == 0);
             if (!should_emit(arg->type())) {
                 emit_unsafe(arg);
                 continue;
             }
-            auto val = emit(arg);
-            values.emplace_back(val);
+            args.emplace_back(emit(arg));
         }
+        return args;
+    };
 
-        switch (values.size()) {
-            case 0:  bb->terminator.return_void(); break;
-            case 1:  bb->terminator.return_value(values[0]); break;
-            default: bb->terminator.return_value(emit_composite(bb, builder_->current_fn_->fn_ret_type, values));
-        }
-    } else if (auto dst_cont = app.callee()->isa_nom<Continuation>(); dst_cont && dst_cont->is_basicblock()) { // ordinary jump
-        int index = -1;
-        for (auto& arg : app.args()) {
-            index++;
-            if (!should_emit(arg->type())) {
-                emit_unsafe(arg);
-                continue;
-            }
-            auto val = emit(arg);
-            auto* param = dst_cont->param(index);
-            auto& phi = cont2bb_[dst_cont]->phis_map[param];
-            phi.preds.emplace_back(val, emit_as_bb(continuation));
-        }
-        bb->terminator.branch(emit(dst_cont));
-    } else if (app.callee() == world().branch()) {
+    if (app.callee() == world().branch()) {
         auto mem = app.arg(0);
         emit_unsafe(mem);
 
@@ -428,31 +415,15 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
         emit_unsafe(app.arg(0));
 
         auto productions = emit_intrinsic(app, intrinsic, bb);
-        auto succ = app.args().back()->isa_nom<Continuation>();
-        jump_to_next_cont_with_args(succ, productions);
-    } else { // function/closure call
-        // put all first-order args into an array
-        std::vector<Id> call_args;
-        const Def* ret_arg = nullptr;
-        for (auto arg : app.args()) {
-            if (arg->order() == 0) {
-                auto arg_type = arg->type();
-                if (arg_type == world().unit_type() || arg_type == world().mem_type()) {
-                    emit_unsafe(arg);
-                    continue;
-                }
-                auto arg_val = emit(arg);
-                call_args.push_back(arg_val);
-            } else {
-                assert(!ret_arg);
-                ret_arg = arg;
-            }
-        }
+        emit_jump(bb, app.ret_arg(), productions);
+    } else if (auto codom = app.callee_type()->codomain()) { // function/closure call
+        auto args = emit_args();
 
         Id call_result;
         if (auto called_continuation = app.callee()->isa_nom<Continuation>()) {
+            // TODO: fn calls
             auto ret_type = get_codom_type(called_continuation->type());
-            call_result = bb->call(ret_type, emit(called_continuation), call_args);
+            call_result = bb->call(ret_type, emit(called_continuation), args);
         } else {
             // must be a closure
             THORIN_UNREACHABLE;
@@ -462,35 +433,33 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
             // call = irbuilder.CreateCall(irbuilder.CreateExtractValue(closure, 0), args);
         }
 
-        // must be call + continuation --- call + return has been removed by codegen_prepare
-        auto succ = ret_arg->isa_nom<Continuation>();
-
-        size_t real_params_count = 0;
-        const Param* last_param = nullptr;
-        for (auto param : succ->params()) {
-            if (!should_emit(param->type()))
+        // count the number of params the return point will have
+        size_t return_values_count = 0;
+        for (auto param_type : *codom) {
+            if (!should_emit(param_type))
                 continue;
-            last_param = param;
-            real_params_count++;
+            return_values_count++;
         }
 
-        std::vector<Id> args(real_params_count);
-
-        if (real_params_count == 1) {
-            args[0] = call_result;
-        } else if (real_params_count > 1) {
-            for (size_t i = 0, j = 0; i != succ->num_params(); ++i) {
-                auto param = succ->param(i);
-                if (!should_emit(param->type()))
+        // map the single return value to the possibly multiple params of the return point
+        std::vector<Id> return_values(return_values_count);
+        if (return_values_count == 1) {
+            return_values[0] = call_result;
+        } else if (return_values_count > 1) {
+            for (size_t i = 0, j = 0; i != codom->size(); ++i) {
+                auto param_type = (*codom)[i];
+                if (!should_emit(param_type))
                     continue;
-                args[j] = bb->extract(convert(param->type()).id, call_result, { (uint32_t) j });
+                return_values[j] = bb->extract(convert(param_type).id, call_result, { (uint32_t) j });
                 j++;
             }
-
-            bb->terminator.branch(emit(succ));
         }
 
-        jump_to_next_cont_with_args(succ, args);
+        emit_jump(bb, app.ret_arg(), return_values);
+    } else {
+        // return, tailcall or BB call
+        auto args = emit_args();
+        emit_jump(bb, app.callee(), args);
     }
 }
 
@@ -522,20 +491,11 @@ Id CodeGen::emit_constant(const thorin::Def* def) {
             }
         }
         return constant;
+    } else if (auto rp = def->isa<ReturnPoint>()) {
+        return emit(rp->continuation());
     }
 
     assertf(false, "Incomplete emit(def) definition");
-}
-
-bool CodeGen::should_emit(const thorin::Type* type) {
-    if (type == world().mem_type())
-        return false;
-    if (auto fn_t = type->isa<FnType>())
-        return fn_t->is_returning();
-    auto converted = convert_maybe_void(type);
-    if (converted.id == builder_->declare_void_type())
-        return false;
-    return true;
 }
 
 std::vector<Id> CodeGen::emit_args(Defs defs) {

--- a/src/thorin/be/spirv/spirv.h
+++ b/src/thorin/be/spirv/spirv.h
@@ -84,6 +84,8 @@ protected:
     Id emit_composite(BasicBlockBuilder* bb, Id, ArrayRef<Id>);
     Id emit_ptr_bitcast(BasicBlockBuilder* bb, const PtrType* from, const PtrType* to, Id);
 
+    void emit_jump(BasicBlockBuilder* bb, const Def* to, std::vector<Id> args);
+
     std::tuple<std::vector<Id>, Id> get_dom_codom(const FnType* fn);
     Id get_codom_type(const FnType*);
 

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -147,7 +147,6 @@ public:
 
 private:
     Continuation(World&, const FnType* pi, const Attributes& attributes, Debug dbg);
-    virtual ~Continuation() { for (auto param : params()) delete param; }
 
 public:
     const FnType* type() const { return Def::type()->as<FnType>(); }

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -66,9 +66,15 @@ public:
     };
 
     const Def* callee() const { return op(Ops::Callee); }
+    const FnType* callee_type() const { return callee()->type()->as<FnType>(); }
     const Def* arg(size_t i) const { return op(Ops::FirstArg + i); }
     size_t num_args() const { return num_ops() - Ops::FirstArg; }
     const Defs args() const { return ops().skip_front(Ops::FirstArg); }
+    const Def* ret_arg() const {
+        if (auto index = callee_type()->ret_param_index(); index >= 0)
+            return arg(index);
+        return nullptr;
+    }
     const Def* rebuild(World&, const Type*, Defs) const override;
 
     Continuations using_continuations() const {

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -86,6 +86,16 @@ public:
     friend class World;
 };
 
+class ReturnPoint : public Def {
+private:
+    ReturnPoint(World&, const Continuation* destination, Debug dbg);
+
+public:
+    const Def* rebuild(World&, const Type*, Defs) const override;
+    Continuation* continuation() const { return op(0)->as_nom<Continuation>(); }
+    friend class World;
+};
+
 //------------------------------------------------------------------------------
 
 enum class CC : uint8_t {

--- a/src/thorin/rec_stream.cpp
+++ b/src/thorin/rec_stream.cpp
@@ -195,6 +195,8 @@ Stream& Type::stream(Stream& s) const {
         return s.fmt("[{} x {}]", t->dim(), t->elem_type());
     } else if (auto t = isa<ClosureType>()) {
         return s.fmt("closure [{, }]", t->ops());
+    } else if (auto t = isa<ReturnType>()) {
+        return s.fmt("return[{, }]", t->ops());
     } else if (auto t = isa<FnType>()) {
         return s.fmt("fn[{, }]", t->ops());
     } else if (auto t = isa<IndefiniteArrayType>()) {

--- a/src/thorin/tables/nodetable.h
+++ b/src/thorin/tables/nodetable.h
@@ -45,13 +45,15 @@
         THORIN_NODE(Assembly, asm)
     THORIN_NODE(Param, param)
     THORIN_NODE(Filter, filter)
+    THORIN_NODE(App, app)
+    THORIN_NODE(ReturnPoint, return)
     // Type
         // PrimType
         THORIN_NODE(Star, star)
-        THORIN_NODE(App, app)
         THORIN_NODE(DefiniteArrayType, definite_array_type)
         THORIN_NODE(FnType, fn)
         THORIN_NODE(ClosureType, closure_type)
+        THORIN_NODE(ReturnType, return_type)
         THORIN_NODE(FrameType, frame)
         THORIN_NODE(IndefiniteArrayType, indefinite_array_type)
         THORIN_NODE(Lambda, lambda)

--- a/src/thorin/transform/cleanup_world.cpp
+++ b/src/thorin/transform/cleanup_world.cpp
@@ -105,7 +105,8 @@ void Cleaner::eliminate_params() {
         if (ocontinuation->has_body() && !world().is_external(ocontinuation)) {
             auto obody = ocontinuation->body();
             for (auto use : ocontinuation->uses()) {
-                if (use.index() != 0 || !use->isa_nom<Continuation>())
+                bool is_call = use->isa_nom<App>() && use.index() == App::Ops::Callee;
+                if (!is_call)
                     goto next_continuation;
             }
 

--- a/src/thorin/transform/codegen_prepare.cpp
+++ b/src/thorin/transform/codegen_prepare.cpp
@@ -9,26 +9,30 @@ struct CodegenPrepare : public Rewriter {
 
     DefMap<Continuation*> wrappers;
 
-    void make_wrapper(const Def* old_return_param) {
+    Continuation* make_wrapper(const Def* old_return_param) {
         assert(old_return_param);
-        assert(!wrappers.contains(old_return_param));
+        if (auto found = wrappers.lookup(old_return_param))
+            return *found;
         auto npi = instantiate(old_return_param->type())->as<FnType>();
         npi = dst().fn_type(npi->types());
         auto wrapper = dst().continuation(npi, old_return_param->debug());
         wrappers[old_return_param] = wrapper;
+        return wrapper;
     }
 
     const Def* rewrite(const Def* odef) override {
         if (auto app = odef->isa<App>()) {
             auto new_ops = Array<const Def*>(app->num_args(), [&](size_t i) -> const Def* {
-                if (auto wrapped = wrappers.lookup(app->arg(i)); wrapped.has_value()) {
+                auto op = app->arg(i);
+                if (op->isa<Param>() && op->type()->isa<ReturnType>()) {
                     // because wrappers bodies need the rewritten ret param, they need to be created lazily
                     // otherwise, rewriting the param would cause the whole scope to be rewritten first, before we get a chance to put anything in the map
-                    if (!(*wrapped)->has_body()) {
+                    auto wrapped = make_wrapper(op);
+                    if (!(wrapped)->has_body()) {
                         auto imported_param = instantiate(app->arg(i));
-                        (*wrapped)->jump(imported_param, (*wrapped)->params_as_defs(), imported_param->debug());
+                        wrapped->jump(imported_param, wrapped->params_as_defs(), imported_param->debug());
                     }
-                    return dst().return_point(*wrapped);
+                    return dst().return_point(wrapped);
                 } else {
                     return instantiate(app->arg(i));
                 }
@@ -40,20 +44,13 @@ struct CodegenPrepare : public Rewriter {
 };
 
 /// this pass makes sure the return param is only called directly, by eta-expanding any uses where it appears in another position
+// TODO: this effectively prevents tail-calls, this shouldn't run if the backend supports tail-calls
 void codegen_prepare(Thorin& thorin) {
     thorin.world().VLOG("start codegen_prepare");
     auto& src = thorin.world();
     auto destination = std::make_unique<World>(src);
     CodegenPrepare pass(src, *destination.get());
 
-    // step one: scan for top-level continuations and register their ret params
-    ScopesForest(src).for_each([&](Scope& scope) {
-        auto ret_param = scope.entry()->ret_param();
-        if (ret_param)
-            pass.make_wrapper(ret_param);
-    });
-
-    // step two: rewrite the world
     for (auto& external : src.externals())
         pass.instantiate(external.second);
 

--- a/src/thorin/transform/codegen_prepare.cpp
+++ b/src/thorin/transform/codegen_prepare.cpp
@@ -19,13 +19,13 @@ struct CodegenPrepare : public Rewriter {
         if (auto app = odef->isa<App>()) {
             auto new_ops = Array<const Def*>(app->num_args(), [&](size_t i) -> const Def* {
                 auto oarg = app->arg(i);
-                if (auto oparam = oarg->isa<Param>()) {
-                    if (oparam == oparam->continuation()->ret_param()) {
+                if (oarg->type()->isa<ReturnType>()) {
+                    if (!oarg->isa<ReturnPoint>()) {
                         auto wrapped = make_wrapper(oarg);
-                        insert(oarg, wrapped);
-                        auto imported_param = instantiate(oparam->continuation())->as_nom<Continuation>()->ret_param();
+                        insert(oarg, dst().return_point(wrapped));
+                        auto imported_param = instantiate(app->arg(i));
                         wrapped->jump(imported_param, wrapped->params_as_defs(), imported_param->debug());
-                        return wrapped;
+                        return dst().return_point(wrapped);
                     }
                 }
                 return instantiate(app->arg(i));

--- a/src/thorin/transform/codegen_prepare.cpp
+++ b/src/thorin/transform/codegen_prepare.cpp
@@ -7,28 +7,31 @@ namespace thorin {
 struct CodegenPrepare : public Rewriter {
     CodegenPrepare(World& src, World& dst) : Rewriter(src, dst) {}
 
-    Continuation* make_wrapper(const Def* old_return_param) {
+    DefMap<Continuation*> wrappers;
+
+    void make_wrapper(const Def* old_return_param) {
         assert(old_return_param);
+        assert(!wrappers.contains(old_return_param));
         auto npi = instantiate(old_return_param->type())->as<FnType>();
         npi = dst().fn_type(npi->types());
         auto wrapper = dst().continuation(npi, old_return_param->debug());
-        return wrapper;
+        wrappers[old_return_param] = wrapper;
     }
 
     const Def* rewrite(const Def* odef) override {
         if (auto app = odef->isa<App>()) {
             auto new_ops = Array<const Def*>(app->num_args(), [&](size_t i) -> const Def* {
-                auto oarg = app->arg(i);
-                if (oarg->type()->isa<ReturnType>()) {
-                    if (!oarg->isa<ReturnPoint>()) {
-                        auto wrapped = make_wrapper(oarg);
-                        insert(oarg, dst().return_point(wrapped));
+                if (auto wrapped = wrappers.lookup(app->arg(i)); wrapped.has_value()) {
+                    // because wrappers bodies need the rewritten ret param, they need to be created lazily
+                    // otherwise, rewriting the param would cause the whole scope to be rewritten first, before we get a chance to put anything in the map
+                    if (!(*wrapped)->has_body()) {
                         auto imported_param = instantiate(app->arg(i));
-                        wrapped->jump(imported_param, wrapped->params_as_defs(), imported_param->debug());
-                        return dst().return_point(wrapped);
+                        (*wrapped)->jump(imported_param, (*wrapped)->params_as_defs(), imported_param->debug());
                     }
+                    return dst().return_point(*wrapped);
+                } else {
+                    return instantiate(app->arg(i));
                 }
-                return instantiate(app->arg(i));
             });
             return dst().app(instantiate(app->callee()), new_ops);
         }
@@ -43,6 +46,14 @@ void codegen_prepare(Thorin& thorin) {
     auto destination = std::make_unique<World>(src);
     CodegenPrepare pass(src, *destination.get());
 
+    // step one: scan for top-level continuations and register their ret params
+    ScopesForest(src).for_each([&](Scope& scope) {
+        auto ret_param = scope.entry()->ret_param();
+        if (ret_param)
+            pass.make_wrapper(ret_param);
+    });
+
+    // step two: rewrite the world
     for (auto& external : src.externals())
         pass.instantiate(external.second);
 

--- a/src/thorin/transform/flatten_tuples.cpp
+++ b/src/thorin/transform/flatten_tuples.cpp
@@ -20,7 +20,7 @@ static const Type* wrapped_type(const FnType* fn_type, size_t max_tuple_size) {
                     nops.push_back(arg);
             } else
                 nops.push_back(op);
-        } else if (auto op_fn_type = op->isa<FnType>()) {
+        } else if (auto op_fn_type = op->isa<FnType>(); op_fn_type && op_fn_type->tag() == NodeTag::Node_FnType) {
             nops.push_back(wrapped_type(op_fn_type, max_tuple_size));
         } else {
             nops.push_back(op);
@@ -98,7 +98,7 @@ static Continuation* wrap_def(Def2Def& wrapped, Def2Def& unwrapped, const Def* o
                 call_args[i + 1] = world.tuple(tuple_args);
             } else
                 call_args[i + 1] = new_cont->param(j++);
-        } else if (auto fn_type = op->isa<FnType>()) {
+        } else if (auto fn_type = op->isa<FnType>(); fn_type && fn_type->tag() == NodeTag::Node_FnType) {
             auto fn_param = new_cont->param(j++);
             // no need to unwrap if the types are identical
             if (fn_param->type() != op)
@@ -149,7 +149,7 @@ static Continuation* unwrap_def(Def2Def& wrapped, Def2Def& unwrapped, const Def*
                     call_args[j++] = world.extract(param, k);
             } else
                 call_args[j++] = param;
-        } else if (auto fn_type = param->type()->isa<FnType>()) {
+        } else if (auto fn_type = param->type()->isa<FnType>(); fn_type && fn_type->tag() == NodeTag::Node_FnType) {
             auto new_fn_type = new_type->op(j - 1)->as<FnType>();
             // no need to wrap if the types are identical
             if (fn_type != new_fn_type)

--- a/src/thorin/transform/importer.cpp
+++ b/src/thorin/transform/importer.cpp
@@ -31,7 +31,7 @@ const Def* Importer::rewrite(const Def* const odef) {
     } else if (auto closure = odef->isa<Closure>()) {
         bool only_called = true;
         for (auto use : closure->uses()) {
-            if (use.def()->isa<App>() && use.index() == 0)
+            if (use.def()->isa<App>() && use.index() == App::Ops::Callee)
                 continue;
             only_called = false;
             break;
@@ -95,7 +95,7 @@ const Def* Importer::rewrite(const Def* const odef) {
                 // permute the arguments and call the parameter instead
                 for (auto use : cont->copy_uses()) {
                     auto uapp = use->isa<App>();
-                    if (uapp && use.index() == 0) {
+                    if (uapp && use.index() == App::Ops::Callee) {
                         todo_ = true;
                         has_calls = true;
                         break;

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -267,6 +267,8 @@ inline bool is_thin(const Type* type) {
     return type->isa<PrimType>() || type->isa<PtrType>() || is_type_unit(type);
 }
 
+class ReturnType;
+
 class FnType : public Type, public TypeOpsMixin<FnType> {
 protected:
     FnType(World& world, Defs ops, NodeTag tag, Debug dbg)
@@ -277,7 +279,12 @@ protected:
 
 public:
     bool is_basicblock() const { return order() == 1; }
-    bool is_returning() const;
+    bool is_returning() const { return ret_param_index() >= 0; }
+    const ReturnType* return_param_type() const;
+    int ret_param_index() const;
+
+    Array<const Type*> domain() const;
+    std::optional<Array<const Type*>> codomain() const;
 
 private:
     const Type* rebuild(World&, const Type*, Defs) const override;
@@ -300,6 +307,17 @@ public:
 
 private:
     int inner_order_;
+
+    friend class World;
+};
+
+class ReturnType : public FnType {
+private:
+    ReturnType(World& world, Defs ops, Debug dbg) : FnType(world, ops, Node_ReturnType, dbg) {}
+
+public:
+    const Type* rebuild(World&, const Type*, Defs) const override;
+    const Type* mangle_for_codegen() const;
 
     friend class World;
 };

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1154,6 +1154,14 @@ const Filter* World::filter(const Defs defs, Debug dbg) {
 
 /// App node does its own folding during construction, and it only sets the ops once
 const App* World::app(const Def* callee, const Defs args, Debug dbg) {
+    while (true) {
+        if (auto ret = callee->isa<ReturnPoint>()) {
+            callee = ret->continuation();
+            continue;
+        }
+        break;
+    }
+
     if (auto continuation = callee->isa<Continuation>()) {
         switch (continuation->intrinsic()) {
             // See also mangle::instantiate when modifying this.

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1291,6 +1291,12 @@ const Def* World::cse_base(const Def* def) {
     return def;
 }
 
+World::~World() {
+    for (const Def* def : data_.defs_) {
+        delete def;
+    }
+}
+
 /*
  * optimizations
  */

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1207,6 +1207,7 @@ const Def* World::return_point(const thorin::Continuation* destination, thorin::
     // but we're wrapping the cont here so we can do just that!
     if (destination->has_body()) {
         auto dbody = destination->body();
+        assert(dbody->callee() != destination);
         if (dbody->callee()->type()->isa<ReturnType>() && dbody->args() == destination->params_as_defs()) {
             Scope s((Continuation*) destination);
             if (!s.contains(dbody->callee())) {

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1185,10 +1185,10 @@ const App* World::app(const Def* callee, const Defs args, Debug dbg) {
         }
     }
 
-    Array<const Def*> ops(1 + args.size());
-    ops[0] = callee;
+    Array<const Def*> ops(App::Ops::FirstArg + args.size());
+    ops[App::Ops::Callee] = callee;
     for (size_t i = 0; i < args.size(); i++)
-        ops[i + 1] = args[i];
+        ops[App::Ops::FirstArg + i] = args[i];
 
     return cse(new App(*this, ops, dbg));
 }

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -124,6 +124,7 @@ public:
     const FnType* fn_type() { return fn_type({}); } ///< Returns an empty @p FnType.
     const FnType* fn_type(Types args);
     const ClosureType* closure_type(Types args);
+    const ReturnType* return_type(Types args);
     const DefiniteArrayType*   definite_array_type(const Type* elem, u64 dim);
     const IndefiniteArrayType* indefinite_array_type(const Type* elem);
 
@@ -275,6 +276,7 @@ public:
     Continuation* match(const Type* type, size_t num_patterns);
     Continuation* end_scope() const { return data_.end_scope_; }
     const App* app(const Def* callee, const Defs args, Debug dbg = {});
+    const ReturnPoint* return_point(const Continuation* destination, Debug dbg = {}) { return cse(new ReturnPoint(*this, destination, dbg)); }
     const Filter* filter(const Defs, Debug dbg = {});
 
     // getters

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -79,6 +79,8 @@ public:
         state_  = other.state_;
     }
 
+    ~World();
+
     /// @name manage global identifier - a unique number for each Def
     //@{
     //u32 cur_gid() const { return state_.cur_gid; }

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -276,7 +276,7 @@ public:
     Continuation* match(const Type* type, size_t num_patterns);
     Continuation* end_scope() const { return data_.end_scope_; }
     const App* app(const Def* callee, const Defs args, Debug dbg = {});
-    const ReturnPoint* return_point(const Continuation* destination, Debug dbg = {}) { return cse(new ReturnPoint(*this, destination, dbg)); }
+    const Def* return_point(const Continuation* destination, Debug dbg = {});
     const Filter* filter(const Defs, Debug dbg = {});
 
     // getters


### PR DESCRIPTION
Revival of the previous "direct-style" changes in https://github.com/AnyDSL/thorin/pull/138.

Unlike #138, this does not make function returns first-class values. Instead, we should have a pass that lowers captured returns to longjmp, implemented as an optional, backend-dependent feature.

---

Thorin uses a CpS IR which naturally represents function returns as continuations. While this form is elegant, it doesn't exactly map to the reality of what our targets can deal with: we actually expect that there is a "return continuation/parameter" that can be known by just looking at the order of the function type (how "deep" the `fn()` type is). We also expect the return argument to always be to a continuation in the calling scope.

Neither of these assumptions are particularly well enforced, and there is a lot of room for ambiguity. This PR adds a special `return_type()` type constructor, much like how we also have `closure_type()`, only functions may have a return type param, and they have only one at most. Continuations (basic blocks) can be transformed into this type using the `return_point` primop.

By making function returns their own type, we gain the following:
 * Ability to enforce _at most_ one return parameter per function
 * Ability to ensure we pass something suitable (e.g. a continuation, or another ret param for tail-recursion) as the function return at a call site, and 
 * Ability to diagnose things we cannot represent for now (capturing a return parameter)
 * Ability to represent non-returning functions (e.g. exception handlers) and allow lifting/closure conversion to deal with those without messing up function returns