### PR TITLE
Rewritten closure conversion + lifting

### DIFF
--- a/src/thorin/CMakeLists.txt
+++ b/src/thorin/CMakeLists.txt
@@ -48,6 +48,8 @@ set(THORIN_SOURCES
     transform/codegen_prepare.cpp
     transform/dead_load_opt.cpp
     transform/dead_load_opt.h
+    transform/demote_closures.cpp
+    transform/demote_closures.h
     transform/hoist_enters.cpp
     transform/hoist_enters.h
     transform/flatten_tuples.cpp

--- a/src/thorin/CMakeLists.txt
+++ b/src/thorin/CMakeLists.txt
@@ -56,6 +56,8 @@ set(THORIN_SOURCES
     transform/importer.h
     transform/inliner.cpp
     transform/inliner.h
+    transform/lift.cpp
+    transform/lift.h
     transform/lift_builtins.cpp
     transform/lift_builtins.h
     transform/mangle.cpp

--- a/src/thorin/CMakeLists.txt
+++ b/src/thorin/CMakeLists.txt
@@ -62,6 +62,8 @@ set(THORIN_SOURCES
     transform/lift.h
     transform/lift_builtins.cpp
     transform/lift_builtins.h
+    transform/lower_closure_env.cpp
+    transform/lower_closure_env.h
     transform/mangle.cpp
     transform/mangle.h
     transform/resolve_loads.cpp

--- a/src/thorin/analyses/schedule.cpp
+++ b/src/thorin/analyses/schedule.cpp
@@ -112,11 +112,19 @@ Continuation* Scheduler::smart(const Def* def) {
     return smart_[def] = s->continuation();
 }
 
+static void add_scope_to_schedule(Schedule& sched, const Scope& s) {
+    sched.push_back(s.entry());
+    for (auto child : s.children_scopes()) {
+        add_scope_to_schedule(sched, s.forest().get_scope(child));
+    }
+}
+
 Schedule schedule(const Scope& scope) {
     // until we have sth better simply use the RPO of the CFG
     Schedule result;
-    for (auto n : scope.f_cfg().reverse_post_order())
-        result.emplace_back(n->continuation());
+    //for (auto n : scope.f_cfg().reverse_post_order())
+    //    result.emplace_back(n->continuation());
+    add_scope_to_schedule(result, scope);
 
     return result;
 }

--- a/src/thorin/analyses/schedule.cpp
+++ b/src/thorin/analyses/schedule.cpp
@@ -124,9 +124,9 @@ static void add_scope_to_schedule(Schedule& sched, const Scope& s) {
 Schedule schedule(const Scope& scope) {
     // until we have sth better simply use the RPO of the CFG
     Schedule result;
-    //for (auto n : scope.f_cfg().reverse_post_order())
-    //    result.emplace_back(n->continuation());
-    add_scope_to_schedule(result, scope);
+    for (auto n : scope.f_cfg().reverse_post_order())
+        result.emplace_back(n->continuation());
+    //add_scope_to_schedule(result, scope);
 
     return result;
 }

--- a/src/thorin/analyses/scope.cpp
+++ b/src/thorin/analyses/scope.cpp
@@ -323,6 +323,29 @@ ContinuationSet ScopesForest::top_level_scopes() {
     return set;
 }
 
+
+std::vector<Continuation*> ScopesForest::parent_scopes_path(Continuation* s) {
+    std::vector<Continuation*> path;
+    while (s) {
+        path.insert(path.begin(), s);
+        s = get_scope(s).parent_scope();
+    }
+    return path;
+}
+
+Continuation* ScopesForest::least_common_ancestor(Continuation* a, Continuation* b) {
+    Scope& sa = get_scope(a);
+    Scope& sb = get_scope(b);
+    auto path_a = parent_scopes_path(a);
+    auto path_b = parent_scopes_path(b);
+    Continuation* best_ancestor = nullptr;
+    for (size_t i = 0; i < path_a.size() && i < path_b.size(); i++) {
+        if (path_b[i] == path_a[i])
+            best_ancestor = path_a[i];
+    }
+    return best_ancestor;
+}
+
 template<bool elide_empty>
 void ScopesForest::for_each(std::function<void(Scope&)> f) {
     for (auto cont : top_level_scopes()) {

--- a/src/thorin/analyses/scope.h
+++ b/src/thorin/analyses/scope.h
@@ -98,6 +98,9 @@ public:
 
     ContinuationSet top_level_scopes();
 
+    std::vector<Continuation*> parent_scopes_path(Continuation*);
+    Continuation* least_common_ancestor(Continuation* a, Continuation* b);
+
     /**
      * Transitively visits all @em reachable Scope%s in @p world that do not have free variables.
      * We call these Scope%s @em top-level Scope%s.

--- a/src/thorin/analyses/verify.cpp
+++ b/src/thorin/analyses/verify.cpp
@@ -8,11 +8,19 @@ namespace thorin {
 
 // TODO this needs serious rewriting
 
-static bool verify_calls(World& world, ScopesForest&) {
+static bool verify_calls(World& world, ScopesForest& forest) {
     bool ok = true;
     for (auto def : world.defs()) {
         if (auto cont = def->isa<Continuation>())
             ok &= cont->verify();
+        if (auto closure = def->isa<Closure>()) {
+            world.VLOG("verifying closure '{}'", closure);
+            auto& scope = forest.get_scope(closure->fn());
+            if (scope.parent_scope()) {
+                world.ELOG("Closure {} has a non-top level fn: {}", closure, closure->fn());
+                ok = false;
+            }
+        }
     }
     return ok;
 }

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -1651,8 +1651,9 @@ void CCodeGen::emit_c_int() {
 
 template <typename T, typename IsInfFn, typename IsNanFn>
 std::string CCodeGen::emit_float(T t, IsInfFn is_inf, IsNanFn is_nan) {
-    auto emit_nn = [&] (std::string def, std::string cuda, std::string opencl) {
+    auto emit_nn = [&] (std::string def, std::string c99, std::string cuda, std::string opencl) {
         switch (lang_) {
+            case Lang::C99:    return c99;
             case Lang::CUDA:   return cuda;
             case Lang::OpenCL: return opencl;
             default:           return def;
@@ -1661,19 +1662,19 @@ std::string CCodeGen::emit_float(T t, IsInfFn is_inf, IsNanFn is_nan) {
 
     if (is_inf(t)) {
         if (std::is_same<T, half>::value) {
-            return emit_nn("std::numeric_limits<half>::infinity()", "__short_as_half(0x7c00)", "as_half(0x7c00)");
+            return emit_nn("std::numeric_limits<half>::infinity()", "((half) INFINITY)", "__short_as_half(0x7c00)", "as_half(0x7c00)");
         } else if (std::is_same<T, float>::value) {
-            return emit_nn("std::numeric_limits<float>::infinity()", "__int_as_float(0x7f800000)", "as_float(0x7f800000)");
+            return emit_nn("std::numeric_limits<float>::infinity()", "((float) INFINITY)", "__int_as_float(0x7f800000)", "as_float(0x7f800000)");
         } else {
-            return emit_nn("std::numeric_limits<double>::infinity()", "__longlong_as_double(0x7ff0000000000000LL)", "as_double(0x7ff0000000000000LL)");
+            return emit_nn("std::numeric_limits<double>::infinity()", "((double) INFINITY)", "__longlong_as_double(0x7ff0000000000000LL)", "as_double(0x7ff0000000000000LL)");
         }
     } else if (is_nan(t)) {
         if (std::is_same<T, half>::value) {
-            return emit_nn("nan(\"\")", "__short_as_half(0x7fff)", "as_half(0x7fff)");
+            return emit_nn("nan(\"\")", "((half) NAN)", "__short_as_half(0x7fff)", "as_half(0x7fff)");
         } else if (std::is_same<T, float>::value) {
-            return emit_nn("nan(\"\")", "__int_as_float(0x7fffffff)", "as_float(0x7fffffff)");
+            return emit_nn("nan(\"\")", "((float) NAN)", "__int_as_float(0x7fffffff)", "as_float(0x7fffffff)");
         } else {
-            return emit_nn("nan(\"\")", "__longlong_as_double(0x7fffffffffffffffLL)", "as_double(0x7fffffffffffffffLL)");
+            return emit_nn("nan(\"\")", "((double) NAN)", "__longlong_as_double(0x7fffffffffffffffLL)", "as_double(0x7fffffffffffffffLL)");
         }
     }
 

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -797,9 +797,10 @@ void CCodeGen::emit_jump(BB& bb, const Def* callee, ArrayRef<std::string> args) 
         // (and it's not recursion)
         if (scope.contains(cont) && cont != entry_) {
             //assert(cont->num_params() == args.size());
-            for (size_t i = 0; i != args.size(); ++i) {
-                if (auto arg = args[i]; !arg.empty())
-                    bb.tail.fmt("p_{} = {};\n", cont->param(i)->unique_name(), arg);
+            size_t i = 0;
+            for (auto param : cont->params()) {
+                if (is_concrete_type(param->type()))
+                    bb.tail.fmt("p_{} = {};\n", param->unique_name(), args[i++]);
             }
             bb.tail.fmt("goto {};", label_name(cont));
             return;

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -1168,6 +1168,8 @@ std::string CCodeGen::emit_def(BB* bb, const Def* def) {
         return name;
     } else if (auto captured_ret = def->isa<CaptureReturn>()) {
         assert(bb);
+        world().WLOG("setjmp required at {}", captured_ret->loc());
+
         // the only valid return to capture is that of the parent cont
         use_longjmp_ = true;
 

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -1591,7 +1591,7 @@ std::string CCodeGen::emit_fun_head(Continuation* cont, bool is_proto) {
     bool needs_comma = false;
     for (size_t i = 0, n = cont->num_params(); i < n; ++i) {
         auto param = cont->param(i);
-        if ((lang_ == Lang::C99 || lang_ == Lang::CUDA) && param->type()->isa<ReturnType>()) {
+        if (param->type()->isa<ReturnType>()) {
             defs_[param] = "";
             continue;
         }

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -330,7 +330,7 @@ std::string CCodeGen::convert(const Type* type) {
         s.fmt("{} data;", convert(Closure::environment_type(world())));
         s.fmt("\b\n}} {};\n", name);
     } else if (auto pi = type->isa<FnType>()) {
-        assert(lang_ == Lang::C99 || lang_ == Lang::CUDA && "Only C and CUDA support function pointers");
+        assert((lang_ == Lang::C99 || lang_ == Lang::CUDA) && "Only C and CUDA support function pointers");
         name = fn_name(pi);
         std::vector<std::string> dom;
         for (auto p : pi->domain()) {
@@ -922,7 +922,14 @@ void CCodeGen::emit_epilogue(Continuation* cont) {
             if (!body->arg(1)->isa<PrimLit>())
                 world().edef(body->arg(1), "reserve_shared: couldn't extract memory size");
 
-            auto ret_cont = body->arg(2)->as_nom<Continuation>();
+            //For now, the return continuation should be lifted to a ReturnPoint, but this might change with intrinsic handling.
+            assert(body->arg(2)->isa<Continuation>() || body->arg(2)->isa<ReturnPoint>());
+            Continuation* ret_cont;
+            if (body->arg(2)->isa<Continuation>())
+                ret_cont = body->arg(2)->as_nom<Continuation>();
+            else
+                ret_cont = body->arg(2)->as<ReturnPoint>()->continuation();
+
             auto elem_type = ret_cont->param(1)->type()->as<PtrType>()->pointee()->as<ArrayType>()->elem_type();
             func_impls_.fmt("{}{} {}_reserved[{}];\n",
                 addr_space_prefix(AddrSpace::Shared), convert(elem_type),
@@ -1584,7 +1591,7 @@ std::string CCodeGen::emit_fun_head(Continuation* cont, bool is_proto) {
     bool needs_comma = false;
     for (size_t i = 0, n = cont->num_params(); i < n; ++i) {
         auto param = cont->param(i);
-        if (lang_ == Lang::C99 && param->type()->isa<ReturnType>()) {
+        if ((lang_ == Lang::C99 || lang_ == Lang::CUDA) && param->type()->isa<ReturnType>()) {
             defs_[param] = "";
             continue;
         }

--- a/src/thorin/be/emitter.h
+++ b/src/thorin/be/emitter.h
@@ -68,7 +68,11 @@ protected:
     /// As above but returning @c !child().is_valid(value) is permitted.
     Value emit_unsafe(const Def* def) {
         if (auto val = defs_.lookup(def)) return *val;
-        if (auto cont = def->isa_nom<Continuation>()) return defs_[cont] = child().emit_fun_decl(cont);
+        if (auto cont = def->isa_nom<Continuation>()) {
+            if (cont->has_body())
+                queue_scope(cont);
+            return defs_[cont] = child().emit_fun_decl(cont);
+        }
 
         auto val = emit_(def);
         return defs_[def] = val;

--- a/src/thorin/be/emitter.h
+++ b/src/thorin/be/emitter.h
@@ -41,7 +41,7 @@ private:
         }
 
         //auto place = def->no_dep() ? entry_ : scheduler_.smart(def);
-        auto place = !scheduler_.scope().contains(def) ? entry_ : scheduler_.smart(def);
+        auto place = !scheduler_.scope().contains(def) ? entry_ : scheduler_.early(def);
 
         if (place) {
             auto& bb = cont2bb_[place];
@@ -79,7 +79,8 @@ protected:
     }
 
     void queue_scope(Continuation* entry) {
-        scopes_to_emit_.push(entry);
+        if (entry->has_body())
+            scopes_to_emit_.push(entry);
     }
 
     void emit_scopes(ScopesForest& forest) {

--- a/src/thorin/be/emitter.h
+++ b/src/thorin/be/emitter.h
@@ -41,7 +41,7 @@ private:
         }
 
         //auto place = def->no_dep() ? entry_ : scheduler_.smart(def);
-        auto place = !scheduler_.scope().contains(def) ? entry_ : scheduler_.early(def);
+        auto place = !scheduler_.scope().contains(def) ? entry_ : scheduler_.smart(def);
 
         if (place) {
             auto& bb = cont2bb_[place];

--- a/src/thorin/be/emitter.h
+++ b/src/thorin/be/emitter.h
@@ -41,7 +41,9 @@ private:
         }
 
         //auto place = def->no_dep() ? entry_ : scheduler_.smart(def);
-        auto place = !scheduler_.scope().contains(def) ? entry_ : scheduler_.smart(def);
+        auto place = nullptr;
+        if (&scheduler_.scope())
+            !scheduler_.scope().contains(def) ? entry_ : scheduler_.smart(def);
 
         if (place) {
             auto& bb = cont2bb_[place];

--- a/src/thorin/be/emitter.h
+++ b/src/thorin/be/emitter.h
@@ -41,9 +41,9 @@ private:
         }
 
         //auto place = def->no_dep() ? entry_ : scheduler_.smart(def);
-        auto place = nullptr;
+        Continuation* place = nullptr;
         if (&scheduler_.scope())
-            !scheduler_.scope().contains(def) ? entry_ : scheduler_.smart(def);
+            place = !scheduler_.scope().contains(def) ? entry_ : scheduler_.smart(def);
 
         if (place) {
             auto& bb = cont2bb_[place];

--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -340,7 +340,7 @@ CodeGen::emit_module() {
 
         Scope& scope = forest.get_scope(todo);
 
-        emit_scope(scope, forest);
+        queue_scope(todo);
 
         for(auto free : scope.free_frontier()) {
             if (const Continuation* cont_const = free->isa<Continuation>()) {
@@ -356,6 +356,8 @@ CodeGen::emit_module() {
         }
     }
 
+    emit_scopes(forest);
+
     if (debug()) dibuilder_.finalize();
 
 #if THORIN_ENABLE_RV
@@ -365,6 +367,8 @@ CodeGen::emit_module() {
 
     rv::lowerIntrinsics(module());
 #endif
+
+    emit_scopes(forest);
 
     verify();
     optimize();

--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -1473,7 +1473,7 @@ void CodeGen::emit_hls(llvm::IRBuilder<>& irbuilder, Continuation* continuation)
     for (size_t i = 2, j = 0; i < body->num_args(); ++i) {
         args[j++] = emit(body->arg(i));
     }
-    auto callee = body->arg(1)->as<Global>()->init()->as_nom<Continuation>();
+    auto callee = body->arg(1)->as_nom<Continuation>();
     world().make_external(callee);
     irbuilder.CreateCall(emit_fun_decl(callee), args);
 }

--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -141,29 +141,28 @@ llvm::Type* CodeGen::convert(const Type* type) {
         case Node_ClosureType:
         case Node_FnType: {
             // extract "return" type, collect all other types
-            auto fn = type->as<FnType>();
-            llvm::Type* ret = nullptr;
+            auto tfn_type = type->as<FnType>();
+            llvm::Type* ret = llvm::Type::getVoidTy(context()); // top-level non-returning continuations should be void
             std::vector<llvm::Type*> ops;
-            for (auto op : fn->types()) {
+            for (auto op : tfn_type->domain()) {
                 if (op->isa<MemType>() || op == world().unit_type()) continue;
-                auto fn = op->isa<FnType>();
-                if (fn && !op->isa<ClosureType>()) {
-                    assert(!ret && "only one 'return' supported");
-                    std::vector<llvm::Type*> ret_types;
-                    for (auto fn_op : fn->types()) {
-                        if (fn_op->isa<MemType>() || fn_op == world().unit_type()) continue;
-                        ret_types.push_back(convert(fn_op));
-                    }
-                    if (ret_types.size() == 0)      ret = llvm::Type::getVoidTy(context());
-                    else if (ret_types.size() == 1) ret = ret_types.back();
-                    else                            ret = llvm::StructType::get(context(), ret_types);
-                } else
-                    ops.push_back(convert(op));
+                ops.push_back(convert(op));
             }
 
-            if (!ret) {
-                ret = llvm::Type::getVoidTy(context());
+            if (tfn_type->is_returning()) {
+                auto ret_ty = tfn_type->return_param_type();
+                assert(ret_ty);
+                std::vector<llvm::Type*> ret_types;
+                for (auto fn_op : ret_ty->types()) {
+                    if (fn_op->isa<MemType>() || fn_op == world().unit_type()) continue;
+                    ret_types.push_back(convert(fn_op));
+                }
+                if (ret_types.size() == 0)      ret = llvm::Type::getVoidTy(context());
+                else if (ret_types.size() == 1) ret = ret_types.back();
+                else                            ret = llvm::StructType::get(context(), ret_types);
             }
+
+            assert(ret);
 
             if (type->tag() == Node_FnType) {
                 auto llvm_type = llvm::FunctionType::get(ret, ops, false);
@@ -171,9 +170,16 @@ llvm::Type* CodeGen::convert(const Type* type) {
             }
 
             auto env_type = convert(Closure::environment_type(world()));
-            auto ptr_type = llvm::PointerType::get(context(), 0);
+            ops.push_back(env_type);
+            auto fn_type = llvm::FunctionType::get(ret, ops, false);
+            auto ptr_type = llvm::PointerType::get(fn_type, 0);
             llvm_type = llvm::StructType::get(context(), { ptr_type, env_type });
             return types_[type] = llvm_type;
+        }
+        case Node_ReturnType: {
+            auto ret_t = type->as<ReturnType>();
+            auto tuple_t = world().tuple_type({ ret_t->mangle_for_codegen(), world().definite_array_type(world().type_qu8(), 200) });
+            return types_[type] = convert(world().ptr_type(tuple_t));
         }
 
         case Node_StructType: {
@@ -427,6 +433,9 @@ llvm::Function* CodeGen::prepare(const Scope& scope) {
         discope_ = disub_program;
     }
 
+    has_alloca_ = false;
+    potential_tailcalls_.clear();
+
     return fct;
 }
 
@@ -478,6 +487,10 @@ void CodeGen::finalize(const Scope&) {
         if (auto variant = def->isa<Variant>(); variant && !variant->value()->has_dep(Dep::Param))
             to_remove.push_back(def);
     }
+    if (!has_alloca_) for (auto call : potential_tailcalls_) {
+        call->setTailCall(true);
+        // call->setTailCallKind(llvm::CallInst::TCK_MustTail);
+    }
     for (auto& def : to_remove)
         defs_.erase(def);
 }
@@ -522,13 +535,15 @@ llvm::CallInst* CodeGen::emit_call(llvm::IRBuilder<>& irbuilder, const Def* call
             }
         }
         return nullptr;
+    } else if (auto return_point = callee->isa<ReturnPoint>()) { // for direct-style calls, just forward to the destination
+        return emit_call(irbuilder, return_point->continuation(), args);
     } else if (callee->isa<Bottom>()) {
         irbuilder.CreateUnreachable();
         return nullptr;
     } else if (auto cont = callee->isa_nom<Continuation>(); cont && scope_->contains(cont) && cont != entry_) {
         assert(cont->is_basicblock());
         size_t j = 0, i = 0;
-        for (auto t: cont->type()->types()) {
+        for (auto t: cont->type()->domain()) {
             i++;
             assert(t->order() == 0);
             if (t->isa<MemType>() || t == world().unit_type())
@@ -601,7 +616,7 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
         }
     } else if (auto callee = body->callee()->isa_nom<Continuation>(); callee && callee->is_intrinsic()) {
         auto args = emit_intrinsic(irbuilder, continuation);
-        call_instr = emit_call(irbuilder, body->arg(callee->ret_param()->index()), args);
+        call_instr = emit_call(irbuilder, body->arg(callee->type()->ret_param_index()), args);
     } else {
         // plain continuation call: we can just emit all the arguments
         std::vector<llvm::Value*> args;
@@ -617,11 +632,11 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
         }
 
         call_instr = emit_call(irbuilder, body->callee(), args);
-        if (body->callee()->type()->as<FnType>()->is_returning() && !body->callee()->isa<Bottom>()) {
+        if (auto codom = body->callee()->type()->as<FnType>()->codomain()) {
             assert(call_instr && "returning calls always involve one of those");
             assert(ret_arg && "we need a return argument too!");
 
-            auto ret_args = split_values(irbuilder, ret_arg->type()->as<FnType>()->types(), call_instr);
+            auto ret_args = split_values(irbuilder, *codom, call_instr);
             call_instr = emit_call(irbuilder, ret_arg, ret_args);
         }
     }
@@ -629,7 +644,7 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
     if (call_instr) {
         // we need to add a dummy return terminator if the last instruction is a call
         if (entry_->type()->is_returning()) {
-            auto entry_return_t = mangle_for_codegen(world(), entry_->ret_param()->type()->as<FnType>()->types());
+            auto entry_return_t = entry_->type()->return_param_type()->mangle_for_codegen();
             if (entry_return_t != world().unit_type()) {
                 irbuilder.CreateRet(llvm::UndefValue::get(convert(entry_return_t)));
             } else
@@ -1071,6 +1086,7 @@ llvm::AllocaInst* CodeGen::emit_alloca(llvm::IRBuilder<>& irbuilder, llvm::Type*
     else
         alloca = new llvm::AllocaInst(type, layout.getAllocaAddrSpace(), nullptr, name, entry->getFirstNonPHIOrDbg());
     alloca->setAlignment(layout.getABITypeAlign(type));
+    has_alloca_ = true;
     return alloca;
 }
 
@@ -1429,10 +1445,10 @@ llvm::Value* CodeGen::emit_reserve_shared(llvm::IRBuilder<>& irbuilder, const Co
     if (!body->arg(1)->isa<PrimLit>())
         world().edef(body->arg(1), "reserve_shared: couldn't extract memory size");
     auto num_elems = body->arg(1)->as<PrimLit>()->ps32_value();
-    auto cont = body->arg(2)->as_nom<Continuation>();
-    auto type = convert(cont->param(1)->type());
+    auto cont_t = body->arg(2)->type()->as<FnType>();
+    auto type = convert(cont_t->domain()[1]);
     // construct array type
-    auto elem_type = cont->param(1)->type()->as<PtrType>()->pointee()->as<ArrayType>()->elem_type();
+    auto elem_type = cont_t->domain()[1]->as<PtrType>()->pointee()->as<ArrayType>()->elem_type();
     auto smem_type = this->convert(continuation->world().definite_array_type(elem_type, num_elems));
     auto name = continuation->unique_name();
     // NVVM doesn't allow '.' in global identifier

--- a/src/thorin/be/llvm/llvm.cpp
+++ b/src/thorin/be/llvm/llvm.cpp
@@ -913,6 +913,11 @@ llvm::Value* CodeGen::emit_builder(llvm::IRBuilder<>& irbuilder, const Def* def)
         }
 
         return llvm_agg;
+    } else if (auto cell = def->isa<Cell>()) {
+        auto alloc = cell->is_heap_allocated() ? emit_alloc(irbuilder, cell->contents()->type(), nullptr) : emit_alloca(irbuilder, convert(cell->contents()->type()), "cell");
+        defs_[cell] = alloc;
+        irbuilder.CreateStore(emit(cell->contents()), alloc);
+        return irbuilder.CreatePtrToInt(alloc, convert(Closure::environment_type(world())));
     } else if (auto aggop = def->isa<AggOp>()) {
         auto llvm_agg = emit_unsafe(aggop->agg());
         auto llvm_idx = emit(aggop->index());

--- a/src/thorin/be/llvm/llvm.h
+++ b/src/thorin/be/llvm/llvm.h
@@ -137,6 +137,8 @@ protected:
     llvm::CallingConv::ID kernel_calling_convention_;
     llvm::DIScope* discope_ = nullptr;
     std::unique_ptr<Runtime> runtime_;
+    bool has_alloca_;
+    std::vector<llvm::CallInst*> potential_tailcalls_;
 #if THORIN_ENABLE_RV
     std::vector<std::tuple<u32, llvm::Function*, llvm::CallInst*>> vec_todo_;
 #endif

--- a/src/thorin/be/llvm/parallel.cpp
+++ b/src/thorin/be/llvm/parallel.cpp
@@ -23,7 +23,7 @@ void CodeGen::emit_parallel(llvm::IRBuilder<>& irbuilder, Continuation* continua
     auto num_threads = emit(body->arg(PAR_ARG_NUMTHREADS));
     auto lower = emit(body->arg(PAR_ARG_LOWER));
     auto upper = emit(body->arg(PAR_ARG_UPPER));
-    auto kernel = body->arg(PAR_ARG_BODY)->as<Global>()->init()->as_nom<Continuation>();
+    auto kernel = body->arg(PAR_ARG_BODY)->as_nom<Continuation>();
 
     const size_t num_kernel_args = body->num_args() - PAR_NUM_ARGS;
 
@@ -114,7 +114,7 @@ void CodeGen::emit_fibers(llvm::IRBuilder<>& irbuilder, Continuation* continuati
     auto num_threads = emit(body->arg(FIB_ARG_NUMTHREADS));
     auto num_blocks = emit(body->arg(FIB_ARG_NUMBLOCKS));
     auto num_warps = emit(body->arg(FIB_ARG_NUMWARPS));
-    auto kernel = body->arg(FIB_ARG_BODY)->as<Global>()->init()->as_nom<Continuation>();
+    auto kernel = body->arg(FIB_ARG_BODY)->as_nom<Continuation>();
 
     const size_t num_kernel_args = body->num_args() - FIB_NUM_ARGS;
 
@@ -198,7 +198,7 @@ llvm::Value* CodeGen::emit_spawn(llvm::IRBuilder<>& irbuilder, Continuation* con
     // Emit memory dependencies up to this point
     emit_unsafe(body->arg(FIB_ARG_MEM));
 
-    auto kernel = body->arg(SPAWN_ARG_BODY)->as<Global>()->init()->as_nom<Continuation>();
+    auto kernel = body->arg(SPAWN_ARG_BODY)->as_nom<Continuation>();
     const size_t num_kernel_args = body->num_args() - SPAWN_NUM_ARGS;
 
     // build parallel-function signature

--- a/src/thorin/be/llvm/runtime.cpp
+++ b/src/thorin/be/llvm/runtime.cpp
@@ -76,7 +76,7 @@ void Runtime::emit_host_code(CodeGen& code_gen, llvm::IRBuilder<>& builder, Plat
 
     auto it_space = body->arg(KernelLaunchArgs::Space);
     auto it_config = body->arg(KernelLaunchArgs::Config);
-    auto kernel = body->arg(KernelLaunchArgs::Body)->as<Global>()->init()->as<Continuation>();
+    auto kernel = body->arg(KernelLaunchArgs::Body)->as<Continuation>();
 
     auto& world = continuation->world();
     //auto kernel_name = builder.CreateGlobalString(kernel->name() == "hls_top" ? kernel->name() : kernel->name());

--- a/src/thorin/be/llvm/runtime.cpp
+++ b/src/thorin/be/llvm/runtime.cpp
@@ -115,8 +115,8 @@ void Runtime::emit_host_code(CodeGen& code_gen, llvm::IRBuilder<>& builder, Plat
             auto ptr = target_arg->type()->as<PtrType>();
             auto rtype = ptr->pointee();
 
-            if (!rtype->isa<ArrayType>())
-                world.edef(target_arg, "currently only pointers to arrays supported as kernel argument; argument has different type: {}", ptr);
+            //if (!rtype->isa<ArrayType>())
+            //    world.edef(target_arg, "currently only pointers to arrays supported as kernel argument; argument has different type: {}", ptr);
 
             auto alloca = code_gen.emit_alloca(builder, builder.getPtrTy(), target_arg->name());
             auto target_ptr = builder.CreatePointerCast(target_val, builder.getPtrTy());

--- a/src/thorin/be/llvm/vectorize.cpp
+++ b/src/thorin/be/llvm/vectorize.cpp
@@ -59,7 +59,7 @@ void CodeGen::emit_vectorize_continuation(llvm::IRBuilder<>& irbuilder, Continua
     emit_unsafe(body->arg(0));
 
     // arguments
-    auto kernel = body->arg(VectorizeArgs::Body)->as<Global>()->init()->as_nom<Continuation>();
+    auto kernel = body->arg(VectorizeArgs::Body)->as_nom<Continuation>();
     const size_t num_kernel_args = body->num_args() - VectorizeArgs::Num;
 
     // build simd-function signature

--- a/src/thorin/be/spirv/spirv.cpp
+++ b/src/thorin/be/spirv/spirv.cpp
@@ -123,13 +123,15 @@ void CodeGen::emit_stream(std::ostream& out) {
     forest.for_each<false>([&](const Scope& scope) {
         if (scope.entry()->is_intrinsic() || scope.entry()->cc() == CC::Device)
             return;
-        emit_scope(scope, forest);
+        queue_scope(scope.entry());
     });
 
     for (auto def : world().defs()) {
         if (auto global = def->isa<Global>())
             builder.interface.push_back(emit(global));
     }
+
+    emit_scopes(forest);
 
     int entry_points_count = 0;
     for (auto& cont : world().copy_continuations()) {

--- a/src/thorin/be/spirv/spirv.cpp
+++ b/src/thorin/be/spirv/spirv.cpp
@@ -218,15 +218,9 @@ static bool is_return_block(thorin::Continuation* cont) {
     for (auto use : cont->copy_uses()) {
         if (use.def()->isa<Param>())
             continue; // the block can have params
-        else if (auto app = use.def()->isa<App>()) {
-            if (auto callee = app->callee()->isa_nom<Continuation>()) {
-                auto arg_index = use.index() - App::FirstArg;
-                auto ret_param = callee->ret_param();
-                if (ret_param && arg_index == ret_param->index()) {
-                    uses_as_ret_param++;
-                    continue;
-                }
-            }
+        if (use.def()->isa<ReturnPoint>()) {
+            uses_as_ret_param++;
+            continue; // the block can be returned to (once)
         }
         return false; // any other use disqualifies the block
     }
@@ -336,15 +330,19 @@ Id CodeGen::emit_as_bb(thorin::Continuation* cont) {
     return cont2bb_[cont]->label;
 }
 
-void CodeGen::emit_epilogue(Continuation* continuation) {
-    if (!continuation->has_body())
-        return;
+void CodeGen::emit_jump(BasicBlockBuilder* bb, const Def* to, std::vector<Id> args) {
+    if (auto ret_point = to->isa<ReturnPoint>()) {
+        to = ret_point->continuation();
+    }
 
-    BasicBlockBuilder* bb = cont2bb_[continuation];
-
-    // Handles the potential nuances of jumping to another continuation
-    auto jump_to_next_cont_with_args = [&](Continuation* succ, std::vector<Id> args) {
-        assert(succ->is_basicblock());
+    if (to == entry_->ret_param()) {
+        switch (args.size()) {
+            case 0:  bb->terminator.return_void(); break;
+            case 1:  bb->terminator.return_value(args[0]); break;
+            default: bb->terminator.return_value(emit_composite(bb, builder_->current_fn_->fn_ret_type, args));
+        }
+    } else if (auto succ = to->isa_nom<Continuation>(); succ && scope_->contains(succ)) {
+        // local BB jump
         BasicBlockBuilder* dstbb = cont2bb_[succ];
 
         for (size_t i = 0, j = 0; i != succ->num_params(); ++i) {
@@ -359,48 +357,37 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
                 defs_[param] = args[j];
             } else {
                 auto& phi = cont2bb_[succ]->phis_map[param];
-                phi.preds.emplace_back(args[j], emit_as_bb(continuation));
+                phi.preds.emplace_back(args[j], bb->label);
             }
             j++;
         }
         bb->terminator.branch(emit(succ));
-    };
+    }
+}
 
+void CodeGen::emit_epilogue(Continuation* continuation) {
+    if (!continuation->has_body())
+        return;
+
+    BasicBlockBuilder* bb = cont2bb_[continuation];
     auto& app = *continuation->body();
 
-    if (app.callee() == entry_->ret_param()) {
-        std::vector<Id> values;
-
+    // calls to intrinsics involve passing basic blocks, which aren't first-class values
+    // however this isn't encoded in their type (fn[...]), and establishing whether they are is hard
+    // instead we can just lazily emit the arguments and deal with the special-case control-flow intrinsics first
+    auto emit_args = [&]() {
+        std::vector<Id> args;
         for (auto arg : app.args()) {
-            assert(arg->order() == 0);
             if (!should_emit(arg->type())) {
                 emit_unsafe(arg);
                 continue;
             }
-            auto val = emit(arg);
-            values.emplace_back(val);
+            args.emplace_back(emit(arg));
         }
+        return args;
+    };
 
-        switch (values.size()) {
-            case 0:  bb->terminator.return_void(); break;
-            case 1:  bb->terminator.return_value(values[0]); break;
-            default: bb->terminator.return_value(emit_composite(bb, builder_->current_fn_->fn_ret_type, values));
-        }
-    } else if (auto dst_cont = app.callee()->isa_nom<Continuation>(); dst_cont && dst_cont->is_basicblock()) { // ordinary jump
-        int index = -1;
-        for (auto& arg : app.args()) {
-            index++;
-            if (!should_emit(arg->type())) {
-                emit_unsafe(arg);
-                continue;
-            }
-            auto val = emit(arg);
-            auto* param = dst_cont->param(index);
-            auto& phi = cont2bb_[dst_cont]->phis_map[param];
-            phi.preds.emplace_back(val, emit_as_bb(continuation));
-        }
-        bb->terminator.branch(emit(dst_cont));
-    } else if (app.callee() == world().branch()) {
+    if (app.callee() == world().branch()) {
         auto mem = app.arg(0);
         emit_unsafe(mem);
 
@@ -428,31 +415,15 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
         emit_unsafe(app.arg(0));
 
         auto productions = emit_intrinsic(app, intrinsic, bb);
-        auto succ = app.args().back()->isa_nom<Continuation>();
-        jump_to_next_cont_with_args(succ, productions);
-    } else { // function/closure call
-        // put all first-order args into an array
-        std::vector<Id> call_args;
-        const Def* ret_arg = nullptr;
-        for (auto arg : app.args()) {
-            if (arg->order() == 0) {
-                auto arg_type = arg->type();
-                if (arg_type == world().unit_type() || arg_type == world().mem_type()) {
-                    emit_unsafe(arg);
-                    continue;
-                }
-                auto arg_val = emit(arg);
-                call_args.push_back(arg_val);
-            } else {
-                assert(!ret_arg);
-                ret_arg = arg;
-            }
-        }
+        emit_jump(bb, app.ret_arg(), productions);
+    } else if (auto codom = app.callee_type()->codomain()) { // function/closure call
+        auto args = emit_args();
 
         Id call_result;
         if (auto called_continuation = app.callee()->isa_nom<Continuation>()) {
+            // TODO: fn calls
             auto ret_type = get_codom_type(called_continuation->type());
-            call_result = bb->call(ret_type, emit(called_continuation), call_args);
+            call_result = bb->call(ret_type, emit(called_continuation), args);
         } else {
             // must be a closure
             THORIN_UNREACHABLE;
@@ -462,35 +433,33 @@ void CodeGen::emit_epilogue(Continuation* continuation) {
             // call = irbuilder.CreateCall(irbuilder.CreateExtractValue(closure, 0), args);
         }
 
-        // must be call + continuation --- call + return has been removed by codegen_prepare
-        auto succ = ret_arg->isa_nom<Continuation>();
-
-        size_t real_params_count = 0;
-        const Param* last_param = nullptr;
-        for (auto param : succ->params()) {
-            if (!should_emit(param->type()))
+        // count the number of params the return point will have
+        size_t return_values_count = 0;
+        for (auto param_type : *codom) {
+            if (!should_emit(param_type))
                 continue;
-            last_param = param;
-            real_params_count++;
+            return_values_count++;
         }
 
-        std::vector<Id> args(real_params_count);
-
-        if (real_params_count == 1) {
-            args[0] = call_result;
-        } else if (real_params_count > 1) {
-            for (size_t i = 0, j = 0; i != succ->num_params(); ++i) {
-                auto param = succ->param(i);
-                if (!should_emit(param->type()))
+        // map the single return value to the possibly multiple params of the return point
+        std::vector<Id> return_values(return_values_count);
+        if (return_values_count == 1) {
+            return_values[0] = call_result;
+        } else if (return_values_count > 1) {
+            for (size_t i = 0, j = 0; i != codom->size(); ++i) {
+                auto param_type = (*codom)[i];
+                if (!should_emit(param_type))
                     continue;
-                args[j] = bb->extract(convert(param->type()).id, call_result, { (uint32_t) j });
+                return_values[j] = bb->extract(convert(param_type).id, call_result, { (uint32_t) j });
                 j++;
             }
-
-            bb->terminator.branch(emit(succ));
         }
 
-        jump_to_next_cont_with_args(succ, args);
+        emit_jump(bb, app.ret_arg(), return_values);
+    } else {
+        // return, tailcall or BB call
+        auto args = emit_args();
+        emit_jump(bb, app.callee(), args);
     }
 }
 
@@ -522,20 +491,11 @@ Id CodeGen::emit_constant(const thorin::Def* def) {
             }
         }
         return constant;
+    } else if (auto rp = def->isa<ReturnPoint>()) {
+        return emit(rp->continuation());
     }
 
     assertf(false, "Incomplete emit(def) definition");
-}
-
-bool CodeGen::should_emit(const thorin::Type* type) {
-    if (type == world().mem_type())
-        return false;
-    if (auto fn_t = type->isa<FnType>())
-        return fn_t->is_returning();
-    auto converted = convert_maybe_void(type);
-    if (converted.id == builder_->declare_void_type())
-        return false;
-    return true;
 }
 
 std::vector<Id> CodeGen::emit_args(Defs defs) {

--- a/src/thorin/be/spirv/spirv.cpp
+++ b/src/thorin/be/spirv/spirv.cpp
@@ -782,7 +782,7 @@ Id CodeGen::emit_bb(BasicBlockBuilder* bb, const Def* def) {
             return bb->ptr_access_chain(type, base, offset, {  });
         }
         if (target_info_.bugs.static_ac_indices_must_be_i32)
-            offset = emit(world().cast(world().type_pu32(), lea->index()));
+            offset = emit_bb(bb, world().cast(world().type_pu32(), lea->index()));
         return bb->access_chain(type, emit(lea->ptr()), { offset });
     } else if (auto aggop = def->isa<AggOp>()) {
         auto agg_type = convert(aggop->agg()->type()).id;

--- a/src/thorin/be/spirv/spirv.cpp
+++ b/src/thorin/be/spirv/spirv.cpp
@@ -179,7 +179,7 @@ static const FnType* patch_entry_point_signature(const FnType* type) {
     for (auto t : type->types()) {
         if (cl_demands_passed_by_reference(t))
             t = world.ptr_type(t, 1, AddrSpace::Function);
-        else if (auto fn = t->isa<FnType>())
+        else if (auto fn = t->isa<FnType>(); fn && fn->tag() == Node_FnType)
             t = patch_entry_point_signature(fn);
         else if (auto ptr = t->isa<PtrType>()) {
             if (ptr->addr_space() == AddrSpace::Generic)
@@ -196,7 +196,7 @@ FnBuilder& CodeGen::get_fn_builder(thorin::Continuation* continuation) {
     }
 
     auto& fn = *(builder_->fn_builders_[continuation] = std::make_unique<FnBuilder>(*builder_));
-    auto fn_type = entry_->type();
+    auto fn_type = continuation->type();
     if (kernel_config_ && kernel_config_->contains(continuation)) {
         fn_type = patch_entry_point_signature(fn_type);
     }

--- a/src/thorin/be/spirv/spirv.h
+++ b/src/thorin/be/spirv/spirv.h
@@ -84,6 +84,8 @@ protected:
     Id emit_composite(BasicBlockBuilder* bb, Id, ArrayRef<Id>);
     Id emit_ptr_bitcast(BasicBlockBuilder* bb, const PtrType* from, const PtrType* to, Id);
 
+    void emit_jump(BasicBlockBuilder* bb, const Def* to, std::vector<Id> args);
+
     std::tuple<std::vector<Id>, Id> get_dom_codom(const FnType* fn);
     Id get_codom_type(const FnType*);
 

--- a/src/thorin/be/spirv/spirv_builder.hpp
+++ b/src/thorin/be/spirv/spirv_builder.hpp
@@ -598,7 +598,19 @@ struct BasicBlockBuilder : public SectionBuilder {
             ref_id(selector);
             ref_id(default_case);
             for (size_t i = 0; i < literals.size(); i++) {
-                ref_id(literals[i]);
+                literal_int(literals[i]);
+                ref_id(cases[i]);
+            }
+        }
+
+        void branch_switch64(Id selector, Id default_case, std::vector<uint64_t> literals, std::vector<uint32_t> cases) {
+            assert(literals.size() == cases.size());
+            begin_op(spv::Op::OpSwitch, 3 + literals.size() * 3);
+            ref_id(selector);
+            ref_id(default_case);
+            for (size_t i = 0; i < literals.size(); i++) {
+                literal_int(literals[i] >> 32);
+                literal_int(literals[i]);
                 ref_id(cases[i]);
             }
         }

--- a/src/thorin/be/spirv/spirv_builder.hpp
+++ b/src/thorin/be/spirv/spirv_builder.hpp
@@ -293,12 +293,14 @@ struct FileBuilder {
         return id;
     }
 
-    Id variable(Id type, spv::StorageClass storage_class) {
-        types_constants.begin_op(spv::Op::OpVariable, 4);
+    Id global_variable(Id type, spv::StorageClass storage_class, std::optional<Id> init = std::nullopt) {
+        types_constants.begin_op(spv::Op::OpVariable, init ? 5 : 4);
         types_constants.ref_id(type);
         auto id = generate_fresh_id();
         types_constants.ref_id(id);
         types_constants.literal_int(storage_class);
+        if (init)
+            types_constants.literal_int(*init);
         return id;
     }
 

--- a/src/thorin/be/spirv/spirv_instructions.cpp
+++ b/src/thorin/be/spirv/spirv_instructions.cpp
@@ -66,8 +66,8 @@ std::tuple<spv::Scope, spv::MemorySemanticsMask> addrspace_atomics_params(World&
 
 std::vector<Id> CodeGen::emit_intrinsic(const App& app, const Continuation* intrinsic, BasicBlockBuilder* bb) {
     auto get_produced_types = [&]() {
-        auto ret_type = (*intrinsic->params().back()).type()->as<FnType>();
-        return *ret_type->codomain();
+        auto fn_type = intrinsic->type();
+        return *(fn_type->codomain());
     };
 
     auto get_produced_type = [&]() {

--- a/src/thorin/be/spirv/spirv_instructions.cpp
+++ b/src/thorin/be/spirv/spirv_instructions.cpp
@@ -203,7 +203,7 @@ std::vector<Id> CodeGen::emit_intrinsic(const App& app, const Continuation* intr
         auto result = bb->op_with_result(spv::Op::OpGroupAll, convert(get_produced_type()).id,  { literal(spv::Scope::ScopeInvocation), emit(app.arg(1)) });
         return { result };
     } else if (intrinsic->name() == "spirv.printf") {
-        Array<const Def*> args = app.args();
+        Array<const Def*> args = app.args().skip_back();
         while (auto bitcast = args[1]->isa<Bitcast>())
             args[1] = bitcast->from();
         return { bb->ext_instruction(convert(get_produced_type()).id, { .set_name = "OpenCL.std", .id = OpenCLLIB::Printf }, emit_args(args)) };

--- a/src/thorin/be/spirv/spirv_instructions.cpp
+++ b/src/thorin/be/spirv/spirv_instructions.cpp
@@ -206,7 +206,7 @@ std::vector<Id> CodeGen::emit_intrinsic(const App& app, const Continuation* intr
         Array<const Def*> args = app.args();
         while (auto bitcast = args[1]->isa<Bitcast>())
             args[1] = bitcast->from();
-        return { bb->ext_instruction(convert(world().unit_type()).id, { .set_name = "OpenCL.std", .id = OpenCLLIB::Printf }, emit_args(args)) };
+        return { bb->ext_instruction(convert(get_produced_type()).id, { .set_name = "OpenCL.std", .id = OpenCLLIB::Printf }, emit_args(args)) };
     }
     world().ELOG("thorin/spirv: Intrinsic '{}' isn't recognised", intrinsic->name());
     exit(-1);

--- a/src/thorin/be/spirv/spirv_types.cpp
+++ b/src/thorin/be/spirv/spirv_types.cpp
@@ -277,14 +277,14 @@ ConvertedType CodeGen::convert(const Type* type) {
 
             if (max_serialized_size > 0) {
                 auto payload_type = world().definite_array_type(world().type_pu8(), max_serialized_size);
-                auto struct_t = world().struct_type(type->name(), 2);
+                auto struct_t = world().struct_type(type->to_string(), 2);
                 struct_t->set_op(0, tag_type);
                 struct_t->set_op(1, payload_type);
                 converted = convert(struct_t);
                 converted.variant.payload_t = std::make_optional(payload_type);
             } else {
                 // We keep this useless level of struct so the rest of the code doesn't need a special path to extract the tag
-                auto struct_t = world().struct_type(type->name(), 1);
+                auto struct_t = world().struct_type(type->to_string(), 1);
                 struct_t->set_op(0, tag_type);
                 converted = convert(struct_t);
             }

--- a/src/thorin/be/spirv/spirv_types.cpp
+++ b/src/thorin/be/spirv/spirv_types.cpp
@@ -23,6 +23,10 @@ uint32_t CodeGen::convert(AddrSpace as) {
             storage_class = spv::StorageClassWorkgroup;
             break;
         }
+        case AddrSpace::Constant: {
+            storage_class = spv::StorageClassUniformConstant;
+            break;
+        }
         case AddrSpace::Push:     storage_class = spv::StorageClassPushConstant;          break;
         case AddrSpace::Input:    storage_class = spv::StorageClassInput;                 break;
         case AddrSpace::Output:   storage_class = spv::StorageClassOutput;                break;

--- a/src/thorin/continuation.cpp
+++ b/src/thorin/continuation.cpp
@@ -58,25 +58,32 @@ bool App::verify() const {
     for (size_t i = 0; i < num_args(); i++) {
         auto pt = callee_type->op(i);
         auto at = arg(i)->type();
-        assertf(pt == at, "app node argument {} has type {} but the callee was expecting {}", this, at, pt);
+        assertf(pt == at, "app node {} argument #{} has type {} but the callee was expecting {}", this, i, at, pt);
     }
     return true;
 }
 
 //------------------------------------------------------------------------------
 
-ReturnPoint::ReturnPoint(thorin::World& world, const thorin::Continuation* destination, thorin::Debug dbg) : Def(world, Node_ReturnPoint, world.return_type(destination->type()->types()), {destination }, dbg) {}
+ReturnPoint::ReturnPoint(World& world, const Continuation* destination, Debug dbg) : Def(world, Node_ReturnPoint, world.return_type(destination->type()->types()), {destination }, dbg) {}
 
-const Def* ReturnPoint::rebuild(thorin::World& world, const thorin::Type*, thorin::Defs nops) const {
+const Def* ReturnPoint::rebuild(World& world, const Type*, Defs nops) const {
     auto def = nops.front();
     // TODO: have some kind of generalised mechanism to obtain the 'real' def
-    while (auto run = def->isa<Run>()) {
-        def = run->def();
-    }
-    while (auto closure = def->isa<Closure>()) {
-        def = closure->fn();
-    }
+    //while (auto run = def->isa<Run>()) {
+    //    def = run->def();
+    //}
+    //while (auto closure = def->isa<Closure>()) {
+    //    def = closure->fn();
+    //}
     return world.return_point(def->as<Continuation>());
+}
+
+CaptureReturn::CaptureReturn(World& world, const Def* ret, Debug dbg)
+    : Def(world, Node_CaptureReturn, world.closure_type(ret->type()->as<ReturnType>()->types()), { ret }, dbg) {}
+
+const Def* CaptureReturn::rebuild(World& w, const Type* t, Defs o) const {
+    return w.capture_return(o[0], debug());
 }
 
 //------------------------------------------------------------------------------

--- a/src/thorin/continuation.cpp
+++ b/src/thorin/continuation.cpp
@@ -24,6 +24,10 @@ const Def* Param::rebuild(World&, const Type*, Defs defs) const {
     const Def* c = defs[0];
     if (auto r = c->isa<Run>())
         c = r->def()->as_nom<Continuation>();
+    // required when rewriting a fn as a closure (say, during closure conversion)
+    while (auto closure = c->isa<Closure>()) {
+        c = closure->fn();
+    }
     auto cont = c->as<Continuation>();
     return cont->param(index());
 }

--- a/src/thorin/continuation.cpp
+++ b/src/thorin/continuation.cpp
@@ -70,9 +70,9 @@ ReturnPoint::ReturnPoint(World& world, const Continuation* destination, Debug db
 const Def* ReturnPoint::rebuild(World& world, const Type*, Defs nops) const {
     auto def = nops.front();
     // TODO: have some kind of generalised mechanism to obtain the 'real' def
-    //while (auto run = def->isa<Run>()) {
-    //    def = run->def();
-    //}
+    while (auto run = def->isa<Run>()) {
+        def = run->def();
+    }
     //while (auto closure = def->isa<Closure>()) {
     //    def = closure->fn();
     //}

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -66,9 +66,15 @@ public:
     };
 
     const Def* callee() const { return op(Ops::Callee); }
+    const FnType* callee_type() const { return callee()->type()->as<FnType>(); }
     const Def* arg(size_t i) const { return op(Ops::FirstArg + i); }
     size_t num_args() const { return num_ops() - Ops::FirstArg; }
     const Defs args() const { return ops().skip_front(Ops::FirstArg); }
+    const Def* ret_arg() const {
+        if (auto index = callee_type()->ret_param_index(); index >= 0)
+            return arg(index);
+        return nullptr;
+    }
     const Def* rebuild(World&, const Type*, Defs) const override;
 
     Continuations using_continuations() const {

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -86,6 +86,16 @@ public:
     friend class World;
 };
 
+class ReturnPoint : public Def {
+private:
+    ReturnPoint(World&, const Continuation* destination, Debug dbg);
+
+public:
+    const Def* rebuild(World&, const Type*, Defs) const override;
+    Continuation* continuation() const { return op(0)->as_nom<Continuation>(); }
+    friend class World;
+};
+
 //------------------------------------------------------------------------------
 
 enum class CC : uint8_t {

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -80,8 +80,11 @@ public:
     Continuations using_continuations() const {
         std::vector<Continuation*> conts;
         for (auto use : uses()) {
-            if (auto cont = use->isa_nom<Continuation>())
+            if (auto cont = use->isa_nom<Continuation>()) {
+                // currently apps are not direct-style and don't yield values, but when that changes stuff will break!
+                assert(use.index() == App::Ops::Callee);
                 conts.push_back(cont);
+            }
         }
         return conts;
     }

--- a/src/thorin/continuation.h
+++ b/src/thorin/continuation.h
@@ -93,12 +93,19 @@ public:
 };
 
 class ReturnPoint : public Def {
-private:
     ReturnPoint(World&, const Continuation* destination, Debug dbg);
 
 public:
     const Def* rebuild(World&, const Type*, Defs) const override;
     Continuation* continuation() const { return op(0)->as_nom<Continuation>(); }
+    friend class World;
+};
+
+class CaptureReturn : public Def {
+    CaptureReturn(World&, const Def* ret, Debug dbg);
+
+public:
+    const Def* rebuild(World&, const Type*, Defs) const override;
     friend class World;
 };
 

--- a/src/thorin/primop.cpp
+++ b/src/thorin/primop.cpp
@@ -140,15 +140,16 @@ Assembly::Assembly(World& world, const Type *type, Defs inputs, std::string asm_
 {}
 
 void Closure::set_fn(thorin::Continuation* f, int self_param_i) {
-    if (self_param_i >= 0) {
-        auto self_param = f->param(self_param_i);
-        auto self_param_t = self_param->type()->isa<ClosureType>();
-        assert(self_param_t && "closure fn self param has to be a closure type");
-        assert(self_param_t == type() && "self param of closure function has to match type of closure");
-        auto f_type_minus_self = world().fn_type(f->type()->types().skip_back(1));
-        auto expected_fn_t = world().fn_type(type()->types());
-        assert(f_type_minus_self == expected_fn_t && "param types of closure fn have to match params of closure");
-    }
+    assert(self_param_i >= 0);
+    //if (self_param_i >= 0) {
+    //    auto self_param = f->param(self_param_i);
+    //    auto self_param_t = self_param->type()->isa<ClosureType>();
+    //    assert(self_param_t && "closure fn self param has to be a closure type");
+    //    assert(self_param_t == type() && "self param of closure function has to match type of closure");
+    //    auto f_type_minus_self = world().fn_type(f->type()->types().skip_back(1));
+    //    auto expected_fn_t = world().fn_type(type()->types());
+    //    assert(f_type_minus_self == expected_fn_t && "param types of closure fn have to match params of closure");
+    //}
     self_param_ = self_param_i;
     set_op(0, f);
 }

--- a/src/thorin/primop.cpp
+++ b/src/thorin/primop.cpp
@@ -139,7 +139,17 @@ Assembly::Assembly(World& world, const Type *type, Defs inputs, std::string asm_
     , flags_(flags)
 {}
 
-void Closure::set_fn(thorin::Continuation* f) {
+void Closure::set_fn(thorin::Continuation* f, int self_param_i) {
+    if (self_param_i >= 0) {
+        auto self_param = f->param(self_param_i);
+        auto self_param_t = self_param->type()->isa<ClosureType>();
+        assert(self_param_t && "closure fn self param has to be a closure type");
+        assert(self_param_t == type() && "self param of closure function has to match type of closure");
+        auto f_type_minus_self = world().fn_type(f->type()->types().skip_back(1));
+        auto expected_fn_t = world().fn_type(type()->types());
+        assert(f_type_minus_self == expected_fn_t && "param types of closure fn have to match params of closure");
+    }
+    self_param_ = self_param_i;
     set_op(0, f);
 }
 
@@ -261,7 +271,7 @@ Def* Closure::stub(thorin::Rewriter& r, const thorin::Type* t) const {
 
 void Closure::rebuild_from(thorin::Rewriter& r, const thorin::Def* old) {
     auto oclosure = old->as<Closure>();
-    set_fn(r.instantiate(oclosure->fn())->as_nom<Continuation>());
+    set_fn(r.instantiate(oclosure->fn())->as_nom<Continuation>(), oclosure->self_param_);
     set_env(r.instantiate(oclosure->env()));
 }
 

--- a/src/thorin/primop.cpp
+++ b/src/thorin/primop.cpp
@@ -106,6 +106,12 @@ Global::Global(World& world, const Def* init, bool is_mutable, Debug dbg)
     assert(!init->has_dep(Dep::Param));
 }
 
+ClosureEnv::ClosureEnv(World& world, const Type* type, const Def* mem, const Def* src, Debug dbg)
+    : MemOp(world, Node_ClosureEnv, nullptr, {mem, src}, dbg)
+{
+    set_type(world.tuple_type({world.mem_type(), type}));
+}
+
 Alloc::Alloc(World& world, const Type* type, const Def* mem, const Def* extra, Debug dbg)
     : MemOp(world, Node_Alloc, nullptr, {mem, extra}, dbg)
 {
@@ -221,6 +227,7 @@ const Def* Variant       ::rebuild(World& w, const Type* t, Defs o) const { retu
 const Def* VariantIndex  ::rebuild(World& w, const Type*  , Defs o) const { return w.variant_index(o[0], debug()); }
 const Def* VariantExtract::rebuild(World& w, const Type*  , Defs o) const { return w.variant_extract(o[0], index(), debug()); }
 const Def* Vector        ::rebuild(World& w, const Type*  , Defs o) const { return w.vector(o, debug()); }
+const Def* ClosureEnv    ::rebuild(World& w, const Type* t, Defs o) const { return w.closure_env(t->as<TupleType>()->op(1)->as<Type>(), o[0], o[1], debug()); }
 
 const Def* Cell::rebuild(World& w, const Type* t, Defs o) const {
     if (is_heap_allocated())

--- a/src/thorin/primop.h
+++ b/src/thorin/primop.h
@@ -576,6 +576,20 @@ private:
     bool equal(const Def* other) const override { return this == other; }
 };
 
+class ClosureEnv : public MemOp {
+private:
+    ClosureEnv(World& world, const Type* type, const Def* mem, const Def* src, Debug dbg);
+
+public:
+    bool has_multiple_outs() const override { return true; }
+    const TupleType* type() const { return MemOp::type()->as<TupleType>(); }
+
+private:
+    const Def* rebuild(World&, const Type*, Defs) const override;
+
+    friend class World;
+};
+
 /// Allocates memory on the heap.
 class Alloc : public MemOp {
 private:

--- a/src/thorin/primop.h
+++ b/src/thorin/primop.h
@@ -345,15 +345,19 @@ private:
     void rebuild_from(thorin::Rewriter &, const thorin::Def *old) override;
     Def* stub(thorin::Rewriter &, const thorin::Type *) const override;
 
+    int self_param_ = -1;
 public:
-    void set_fn(Continuation* f);
+    void set_fn(Continuation* f, int self_param);
     void set_env(const Def* env) {
         set_op(1, env);
     }
     Continuation* fn() const;
     const Def* env() const { return op(1); }
+    int self_param() const { return self_param_; }
     static const Type*    environment_type(World&);
     static const PtrType* environment_ptr_type(World&);
+
+    const ClosureType* type() const { return Aggregate::type()->as<ClosureType>(); }
 
     friend class World;
 };

--- a/src/thorin/primop.h
+++ b/src/thorin/primop.h
@@ -587,6 +587,8 @@ private:
 public:
     bool has_multiple_outs() const override { return true; }
     const TupleType* type() const { return MemOp::type()->as<TupleType>(); }
+    const Type* env_type() const { return type()->types()[1]; }
+    const Def* src() const { return op(1); }
 
 private:
     const Def* rebuild(World&, const Type*, Defs) const override;

--- a/src/thorin/rec_stream.cpp
+++ b/src/thorin/rec_stream.cpp
@@ -195,6 +195,8 @@ Stream& Type::stream(Stream& s) const {
         return s.fmt("[{} x {}]", t->dim(), t->elem_type());
     } else if (auto t = isa<ClosureType>()) {
         return s.fmt("closure [{, }]", t->ops());
+    } else if (auto t = isa<ReturnType>()) {
+        return s.fmt("return[{, }]", t->ops());
     } else if (auto t = isa<FnType>()) {
         return s.fmt("fn[{, }]", t->ops());
     } else if (auto t = isa<IndefiniteArrayType>()) {

--- a/src/thorin/tables/nodetable.h
+++ b/src/thorin/tables/nodetable.h
@@ -45,13 +45,15 @@
         THORIN_NODE(Assembly, asm)
     THORIN_NODE(Param, param)
     THORIN_NODE(Filter, filter)
+    THORIN_NODE(App, app)
+    THORIN_NODE(ReturnPoint, return)
     // Type
         // PrimType
         THORIN_NODE(Star, star)
-        THORIN_NODE(App, app)
         THORIN_NODE(DefiniteArrayType, definite_array_type)
         THORIN_NODE(FnType, fn)
         THORIN_NODE(ClosureType, closure_type)
+        THORIN_NODE(ReturnType, return_type)
         THORIN_NODE(FrameType, frame)
         THORIN_NODE(IndefiniteArrayType, indefinite_array_type)
         THORIN_NODE(Lambda, lambda)

--- a/src/thorin/tables/nodetable.h
+++ b/src/thorin/tables/nodetable.h
@@ -16,6 +16,7 @@
             // Access
                 THORIN_NODE(Load, load)
                 THORIN_NODE(Store, store)
+            THORIN_NODE(ClosureEnv, closure_env)
             THORIN_NODE(Enter, enter)
             THORIN_NODE(Leave, leave)
         THORIN_NODE(Select, select)

--- a/src/thorin/tables/nodetable.h
+++ b/src/thorin/tables/nodetable.h
@@ -12,6 +12,7 @@
             THORIN_NODE(BlobPtr, mem_blob)
         // MemOp
             THORIN_NODE(Alloc, alloc)
+            THORIN_NODE(Cell, cell)
             // Access
                 THORIN_NODE(Load, load)
                 THORIN_NODE(Store, store)

--- a/src/thorin/tables/nodetable.h
+++ b/src/thorin/tables/nodetable.h
@@ -38,6 +38,7 @@
         THORIN_NODE(StructAgg, struct_agg)
         THORIN_NODE(Vector, vector)
         THORIN_NODE(Closure, closure)
+        THORIN_NODE(CaptureReturn, capture_return)
         THORIN_NODE(Extract, extract)
         THORIN_NODE(Insert, insert)
         THORIN_NODE(LEA, lea)
@@ -48,7 +49,7 @@
     THORIN_NODE(Param, param)
     THORIN_NODE(Filter, filter)
     THORIN_NODE(App, app)
-    THORIN_NODE(ReturnPoint, return)
+    THORIN_NODE(ReturnPoint, return_point)
     // Type
         // PrimType
         THORIN_NODE(Star, star)

--- a/src/thorin/transform/cleanup_world.cpp
+++ b/src/thorin/transform/cleanup_world.cpp
@@ -79,9 +79,10 @@ bool Cleaner::eliminate_tail_rec_scope(thorin::Scope& scope) {
         for (size_t i = 0; i != n; ++i) {
             if (args[i] == nullptr) {
                 new_args.emplace_back(entry->param(i));
-                if (entry->param(i)->order() != 0) {
-                    // the resulting function wouldn't be of first order so examine next scope
-                    return false;
+                if (entry->param(i)->type()->isa<ReturnType>()) {
+                    // this would create a non-top level returning function and we aren't allowed those at this point
+                    if (world().is_cff())
+                        return false;
                 }
             }
         }

--- a/src/thorin/transform/cleanup_world.cpp
+++ b/src/thorin/transform/cleanup_world.cpp
@@ -7,6 +7,7 @@
 #include "thorin/transform/mangle.h"
 #include "thorin/transform/resolve_loads.h"
 #include "thorin/transform/partial_evaluation.h"
+#include "demote_closures.h"
 
 namespace thorin {
 
@@ -20,6 +21,7 @@ public:
     void cleanup();
     void eliminate_tail_rec();
     void eliminate_params();
+    void demote_closures();
     void rebuild();
     void verify_closedness();
     void within(const Def*);
@@ -148,6 +150,10 @@ next_continuation:;
     }
 }
 
+void Cleaner::demote_closures() {
+    todo_ |= thorin::demote_closures(*thorin_.world_container());
+}
+
 void Cleaner::rebuild() {
     auto fresh_world = std::make_unique<World>(world());
     Importer importer(world(), *fresh_world);
@@ -241,6 +247,7 @@ void Cleaner::cleanup_fix_point() {
         rebuild();
         eliminate_tail_rec();
         eliminate_params();
+        demote_closures();
         rebuild(); // resolve replaced defs before going to resolve_loads
         todo_ |= resolve_loads(world());
         rebuild();

--- a/src/thorin/transform/cleanup_world.cpp
+++ b/src/thorin/transform/cleanup_world.cpp
@@ -247,7 +247,7 @@ void Cleaner::cleanup_fix_point() {
         rebuild();
         eliminate_tail_rec();
         eliminate_params();
-        demote_closures();
+        //demote_closures();
         rebuild(); // resolve replaced defs before going to resolve_loads
         todo_ |= resolve_loads(world());
         rebuild();

--- a/src/thorin/transform/cleanup_world.cpp
+++ b/src/thorin/transform/cleanup_world.cpp
@@ -105,7 +105,8 @@ void Cleaner::eliminate_params() {
         if (ocontinuation->has_body() && !world().is_external(ocontinuation)) {
             auto obody = ocontinuation->body();
             for (auto use : ocontinuation->uses()) {
-                if (use.index() != 0 || !use->isa_nom<Continuation>())
+                bool is_call = use->isa_nom<App>() && use.index() == App::Ops::Callee;
+                if (!is_call)
                     goto next_continuation;
             }
 

--- a/src/thorin/transform/cleanup_world.cpp
+++ b/src/thorin/transform/cleanup_world.cpp
@@ -247,7 +247,9 @@ void Cleaner::cleanup_fix_point() {
         rebuild();
         eliminate_tail_rec();
         eliminate_params();
-        //demote_closures();
+        verify(world());
+        demote_closures();
+        verify(world());
         rebuild(); // resolve replaced defs before going to resolve_loads
         todo_ |= resolve_loads(world());
         rebuild();

--- a/src/thorin/transform/cleanup_world.cpp
+++ b/src/thorin/transform/cleanup_world.cpp
@@ -48,7 +48,7 @@ bool Cleaner::eliminate_tail_rec_scope(thorin::Scope& scope) {
             } else if (use->isa<Param>())
                 continue; // ignore params
 
-            world().ELOG("non-recursive usage of {} index:{} use:{}", scope.entry()->name(), use.index(), use.def()->to_string());
+            //world().ELOG("non-recursive usage of {} index:{} use:{}", scope.entry()->name(), use.index(), use.def()->to_string());
             only_tail_calls = false;
             break;
         }

--- a/src/thorin/transform/closure_conversion.cpp
+++ b/src/thorin/transform/closure_conversion.cpp
@@ -177,7 +177,10 @@ public:
             wrapper->jump(lifted, wrapper_args);
 
             auto closure_type = convert_type(continuation->type());
-            return world_.closure(closure_type->as<ClosureType>(), wrapper, thin_env ? free_vars[0] : world_.tuple(free_vars), continuation->debug());
+            auto closure = world_.closure(closure_type->as<ClosureType>(), continuation->debug());
+            closure->set_fn(wrapper);
+            closure->set_env(thin_env ? free_vars[0] : world_.tuple(free_vars));
+            return closure;
         } else {
             if (new_defs_.count(def)) return new_defs_[def];
             if (def->isa<Param>() || def->isa<Closure>())

--- a/src/thorin/transform/closure_conversion.cpp
+++ b/src/thorin/transform/closure_conversion.cpp
@@ -178,7 +178,7 @@ public:
 
             auto closure_type = convert_type(continuation->type());
             auto closure = world_.closure(closure_type->as<ClosureType>(), continuation->debug());
-            closure->set_fn(wrapper);
+            closure->set_fn(wrapper, env_param_index);
             closure->set_env(thin_env ? free_vars[0] : world_.tuple(free_vars));
             return closure;
         } else {

--- a/src/thorin/transform/codegen_prepare.cpp
+++ b/src/thorin/transform/codegen_prepare.cpp
@@ -9,26 +9,30 @@ struct CodegenPrepare : public Rewriter {
 
     DefMap<Continuation*> wrappers;
 
-    void make_wrapper(const Def* old_return_param) {
+    Continuation* make_wrapper(const Def* old_return_param) {
         assert(old_return_param);
-        assert(!wrappers.contains(old_return_param));
+        if (auto found = wrappers.lookup(old_return_param))
+            return *found;
         auto npi = instantiate(old_return_param->type())->as<FnType>();
         npi = dst().fn_type(npi->types());
         auto wrapper = dst().continuation(npi, old_return_param->debug());
         wrappers[old_return_param] = wrapper;
+        return wrapper;
     }
 
     const Def* rewrite(const Def* odef) override {
         if (auto app = odef->isa<App>()) {
             auto new_ops = Array<const Def*>(app->num_args(), [&](size_t i) -> const Def* {
-                if (auto wrapped = wrappers.lookup(app->arg(i)); wrapped.has_value()) {
+                auto op = app->arg(i);
+                if (op->isa<Param>() && op->type()->isa<ReturnType>()) {
                     // because wrappers bodies need the rewritten ret param, they need to be created lazily
                     // otherwise, rewriting the param would cause the whole scope to be rewritten first, before we get a chance to put anything in the map
-                    if (!(*wrapped)->has_body()) {
+                    auto wrapped = make_wrapper(op);
+                    if (!(wrapped)->has_body()) {
                         auto imported_param = instantiate(app->arg(i));
-                        (*wrapped)->jump(imported_param, (*wrapped)->params_as_defs(), imported_param->debug());
+                        wrapped->jump(imported_param, wrapped->params_as_defs(), imported_param->debug());
                     }
-                    return dst().return_point(*wrapped);
+                    return dst().return_point(wrapped);
                 } else {
                     return instantiate(app->arg(i));
                 }
@@ -40,20 +44,13 @@ struct CodegenPrepare : public Rewriter {
 };
 
 /// this pass makes sure the return param is only called directly, by eta-expanding any uses where it appears in another position
+// TODO: this effectively prevents tail-calls, this shouldn't run if the backend supports tail-calls
 void codegen_prepare(Thorin& thorin) {
     thorin.world().VLOG("start codegen_prepare");
     auto& src = thorin.world();
     auto destination = std::make_unique<World>(src);
     CodegenPrepare pass(src, *destination.get());
 
-    // step one: scan for top-level continuations and register their ret params
-    ScopesForest(src).for_each([&](Scope& scope) {
-        auto ret_param = scope.entry()->ret_param();
-        if (ret_param)
-            pass.make_wrapper(ret_param);
-    });
-
-    // step two: rewrite the world
     for (auto& external : src.externals())
         pass.instantiate(external.second);
 

--- a/src/thorin/transform/codegen_prepare.cpp
+++ b/src/thorin/transform/codegen_prepare.cpp
@@ -19,13 +19,13 @@ struct CodegenPrepare : public Rewriter {
         if (auto app = odef->isa<App>()) {
             auto new_ops = Array<const Def*>(app->num_args(), [&](size_t i) -> const Def* {
                 auto oarg = app->arg(i);
-                if (auto oparam = oarg->isa<Param>()) {
-                    if (oparam == oparam->continuation()->ret_param()) {
+                if (oarg->type()->isa<ReturnType>()) {
+                    if (!oarg->isa<ReturnPoint>()) {
                         auto wrapped = make_wrapper(oarg);
-                        insert(oarg, wrapped);
-                        auto imported_param = instantiate(oparam->continuation())->as_nom<Continuation>()->ret_param();
+                        insert(oarg, dst().return_point(wrapped));
+                        auto imported_param = instantiate(app->arg(i));
                         wrapped->jump(imported_param, wrapped->params_as_defs(), imported_param->debug());
-                        return wrapped;
+                        return dst().return_point(wrapped);
                     }
                 }
                 return instantiate(app->arg(i));

--- a/src/thorin/transform/codegen_prepare.cpp
+++ b/src/thorin/transform/codegen_prepare.cpp
@@ -7,28 +7,31 @@ namespace thorin {
 struct CodegenPrepare : public Rewriter {
     CodegenPrepare(World& src, World& dst) : Rewriter(src, dst) {}
 
-    Continuation* make_wrapper(const Def* old_return_param) {
+    DefMap<Continuation*> wrappers;
+
+    void make_wrapper(const Def* old_return_param) {
         assert(old_return_param);
+        assert(!wrappers.contains(old_return_param));
         auto npi = instantiate(old_return_param->type())->as<FnType>();
         npi = dst().fn_type(npi->types());
         auto wrapper = dst().continuation(npi, old_return_param->debug());
-        return wrapper;
+        wrappers[old_return_param] = wrapper;
     }
 
     const Def* rewrite(const Def* odef) override {
         if (auto app = odef->isa<App>()) {
             auto new_ops = Array<const Def*>(app->num_args(), [&](size_t i) -> const Def* {
-                auto oarg = app->arg(i);
-                if (oarg->type()->isa<ReturnType>()) {
-                    if (!oarg->isa<ReturnPoint>()) {
-                        auto wrapped = make_wrapper(oarg);
-                        insert(oarg, dst().return_point(wrapped));
+                if (auto wrapped = wrappers.lookup(app->arg(i)); wrapped.has_value()) {
+                    // because wrappers bodies need the rewritten ret param, they need to be created lazily
+                    // otherwise, rewriting the param would cause the whole scope to be rewritten first, before we get a chance to put anything in the map
+                    if (!(*wrapped)->has_body()) {
                         auto imported_param = instantiate(app->arg(i));
-                        wrapped->jump(imported_param, wrapped->params_as_defs(), imported_param->debug());
-                        return dst().return_point(wrapped);
+                        (*wrapped)->jump(imported_param, (*wrapped)->params_as_defs(), imported_param->debug());
                     }
+                    return dst().return_point(*wrapped);
+                } else {
+                    return instantiate(app->arg(i));
                 }
-                return instantiate(app->arg(i));
             });
             return dst().app(instantiate(app->callee()), new_ops);
         }
@@ -43,6 +46,14 @@ void codegen_prepare(Thorin& thorin) {
     auto destination = std::make_unique<World>(src);
     CodegenPrepare pass(src, *destination.get());
 
+    // step one: scan for top-level continuations and register their ret params
+    ScopesForest(src).for_each([&](Scope& scope) {
+        auto ret_param = scope.entry()->ret_param();
+        if (ret_param)
+            pass.make_wrapper(ret_param);
+    });
+
+    // step two: rewrite the world
     for (auto& external : src.externals())
         pass.instantiate(external.second);
 

--- a/src/thorin/transform/demote_closures.cpp
+++ b/src/thorin/transform/demote_closures.cpp
@@ -10,12 +10,12 @@ struct ClosureDemoter {
             if (!cont->has_body())
                 continue;
             auto app = cont->body();
-            if (auto closure = app->callee()->isa<Closure>())
+            if (auto closure = app->callee()->isa_nom<Closure>())
                 run(closure);
         }
     }
 
-    void run(const Closure* closure) {
+    void run(Closure* closure) {
         if (processed_.contains(closure)) {
             return;
         }
@@ -25,27 +25,36 @@ struct ClosureDemoter {
             if (closure->self_param() < 0)
                 return;
 
-            bool called_directly = false;
+            bool closure_needed = false;
+            std::vector<const App*> called_directly;
             for (auto use : closure->uses()) {
-                if (use.def()->isa<App>() && use.index() == App::Ops::Callee) {
-                    called_directly = true;
-                    break;
+                if (auto app = use.def()->isa<App>(); app && use.index() == App::Ops::Callee) {
+                    called_directly.push_back(app);
+                    continue;
                 }
+                //if (auto app = use.def()->isa<App>(); app && app->callee() == closure->fn() && (int) use.index() == closure->self_param()) {
+                //    continue;
+                //}
+                closure_needed = true;
             }
 
             // if the closure is never called directly, we'd be wasting our time
-            if (called_directly) {
+            if (!called_directly.empty()) {
                 bool self_param_ok = true;
                 const Param* self_param = closure->fn()->param(closure->self_param());
+                const ClosureEnv* env = nullptr;
                 for (auto use : self_param->uses()) {
                     // the closure argument can be used, but only to extract the environment!
-                    if (use.def()->isa<ClosureEnv>())
+                    if (auto e = use.def()->isa<ClosureEnv>()) {
+                        assert(!env);
+                        env = e;
                         continue;
+                    }
                     self_param_ok = false;
                     break;
                 }
 
-                if (self_param_ok) {
+                if (self_param_ok && !closure_needed) {
                     //world_.VLOG("demote_closures: {} is called directly, which we can simplify", closure);
                     //todo_ = true;
 
@@ -58,31 +67,45 @@ struct ClosureDemoter {
                         wrapper_args.push_back(p);
 
                     auto dummy_closure = world_.closure((closure->type())->as<ClosureType>());
-                    // the dummy closure has a dummy function and no self param
-                    dummy_closure->set_fn(world_.continuation((closure->fn()->type())->as<FnType>()), -1);
                     // the dummy closure environment is a new wrapper param (closure lives in wrapper scope)
                     auto env_param = wrapper->append_param(closure->env()->type());
                     dummy_closure->set_env(env_param);
 
+                    auto fn = closure->fn();
+
+                    // if the closure isn't needed at all, get rid of the self param uses
+                    // next round of dead param elimination will do it in
+                    if (!closure_needed) {
+                        if (env)
+                            env->replace_uses(world_.tuple({env->mem(), env_param}));
+                        auto dead_fn = world_.continuation(closure->fn()->type());
+                        dummy_closure->set_fn(dead_fn, closure->self_param());
+                        closure->unset_op(0);
+                        closure->set_fn(dead_fn, closure->self_param());
+                    } else {
+                        // the dummy closure has a dummy function and no self param
+                        // TODO: this duplicates the closure and that's no good
+                        // (later replace_uses screws up the scope of one of them)
+                        dummy_closure->set_fn(closure->fn(), closure->self_param());
+                    }
+
                     // if we had a self param, make sure we insert the closure where that was
                     wrapper_args.insert(wrapper_args.begin() + closure->self_param(), dummy_closure);
 
-                    world_.VLOG("simplify: old env: {} new env: {} param: {}", closure->env()->type(), dummy_closure->env()->type(), env_param->type());
-                    wrapper->jump(world_.run((closure->fn())), wrapper_args);
+                    world_.VLOG("demoted closure {}", closure);
+                    wrapper->jump(world_.run(fn), wrapper_args);
 
-                    replace_calls(closure, wrapper);
+                    replace_calls(called_directly, closure, wrapper);
                 }
             }
         }
     }
 
-    void replace_calls(const Closure* closure, Continuation* wrapper) {
-        for (auto use : closure->copy_uses()) {
-            if (auto app = use.def()->isa<App>(); app && use.index() == App::Ops::Callee) {
-                world_.VLOG("demote_closures: {} calls closure {} which only consumes its environment, replacing with wrapper {}", app, closure, wrapper);
-                use->replace_uses(world_.app(wrapper, concat(static_cast<ArrayRef<const Def*>>(app->args()), closure->env()), app->debug()));
-                todo_ = true;
-            }
+    void replace_calls(std::vector<const App*>& calls, const Closure* closure, Continuation* wrapper) {
+        for (auto app : calls) {
+            world_.VLOG("demote_closures: {} calls closure {} which only consumes its environment, replacing with wrapper {}", app, closure, wrapper);
+            app->replace_uses(world_.app(wrapper, concat(static_cast<ArrayRef<const Def*>>(app->args()), closure->env()), app->debug()));
+            todo_ = true;
         }
     }
 

--- a/src/thorin/transform/demote_closures.cpp
+++ b/src/thorin/transform/demote_closures.cpp
@@ -1,0 +1,84 @@
+#include "demote_closures.h"
+
+namespace thorin {
+
+struct ClosureDemoter {
+    ClosureDemoter(World& world) : world_(world) {}
+
+    void run() {
+        for (auto cont : world_.copy_continuations()) {
+            if (!cont->has_body())
+                continue;
+            auto app = cont->body();
+            if (auto closure = app->callee()->isa<Closure>())
+                run(closure);
+        }
+    }
+
+    void run(const Closure* closure) {
+        if (processed_.contains(closure)) {
+            return;
+        }
+        processed_.insert(closure);
+        if (closure->fn()->has_body()) {
+            //assert(!lookup(closure->fn()) && "fn can't be rewritten yet");
+            bool only_called = true;
+            for (auto use : closure->uses()) {
+                if (use.def()->isa<App>() && use.index() == App::Ops::Callee)
+                    continue;
+                only_called = false;
+                break;
+            }
+            if (only_called) {
+                bool self_param_ok = true;
+                auto self_param = closure->fn()->params().back();
+                for (auto use : self_param->uses()) {
+                    // the closure argument can be used, but only to extract the environment!
+                    //if (auto extract = use.def()->isa<Extract>(); extract && is_primlit(extract->index(), 1))
+                    //    continue;
+                    if (use.def()->isa<ClosureEnv>())
+                        continue;
+                    self_param_ok = false;
+                    break;
+                }
+                auto fn_t = (closure->fn()->type())->as<FnType>();
+                auto types = fn_t->copy_types();//.skip_back(1);
+                fn_t = world_.fn_type(types.skip_back(1));
+
+                world_.VLOG("simplify: eliminating closure {} as it is never passed as an argument, and is not recursive", closure);
+                todo_ = true;
+
+                auto wrapper = world_.continuation(fn_t, closure->fn()->debug());
+                //Array<const Def*> args(closure->fn()->num_params());
+                auto dummy_closure = world_.closure((closure->type())->as<ClosureType>());
+                dummy_closure->set_fn(world_.continuation((closure->fn()->type())->as<FnType>()));
+                auto env_param = wrapper->append_param(closure->env()->type());
+                dummy_closure->set_env(env_param);
+                wrapper->jump(world_.run((closure->fn())), concat(wrapper->params_as_defs().skip_back(1), static_cast<const Def*>(dummy_closure)));
+
+                replace_calls(closure, wrapper);
+            }
+        }
+    }
+
+    void replace_calls(const Closure* closure, Continuation* wrapper) {
+        for (auto use : closure->copy_uses()) {
+            if (auto app = use.def()->isa<App>()) {
+                use->replace_uses(world_.app(wrapper, concat(static_cast<ArrayRef<const Def*>>(app->args()), closure->env()), app->debug()));
+                todo_ = true;
+            }
+        }
+    }
+
+    World& world_;
+    bool todo_ = false;
+    DefSet processed_;
+};
+
+bool demote_closures(World& world) {
+    ClosureDemoter pass(world);
+    pass.run();
+    return pass.todo_;
+}
+
+}

--- a/src/thorin/transform/demote_closures.cpp
+++ b/src/thorin/transform/demote_closures.cpp
@@ -59,11 +59,10 @@ struct ClosureDemoter {
 
                 if (self_param_ok && !closure_needed) {
                     auto fn = closure->fn();
-                    //auto env_param = fn->append_param(closure->env()->type());
 
                     auto old_fn_uses = fn->copy_uses();
                     if (env) {
-                        Scope cope(fn);
+                        Scope scope(fn);
 
                         auto args = Array<const Def*>(fn->num_params());
                         const Def* dummy_closure = world_.bottom(closure->type());
@@ -71,14 +70,10 @@ struct ClosureDemoter {
                             args[closure->self_param()] = dummy_closure;
 
                         struct R : public Mangler {
-                            explicit R(Scope& s, Defs args, const ClosureEnv* env) : Mangler(s, s.entry(), args), env_(env) {
-                                //auto fn = instantiate(f)->as_nom<Continuation>();
-                            }
+                            explicit R(Scope& s, Defs args, const ClosureEnv* env) : Mangler(s, s.entry(), args), env_(env) {}
 
                             const Def* rewrite(const thorin::Def* odef) override {
                                 if (odef == env_) {
-                                    //auto fn = instantiate(fn_)->as_nom<Continuation>();
-                                    //auto env_param = fn->append_param(env_->type());
                                     auto env_param = add_param(env_->env_type());
                                     return dst().tuple({ instantiate(env_->mem()), env_param});
                                 }
@@ -86,7 +81,7 @@ struct ClosureDemoter {
                             }
 
                             const ClosureEnv* env_;
-                        } r(cope, args, env);
+                        } r(scope, args, env);
 
                         fn = r.mangle();
                     }

--- a/src/thorin/transform/demote_closures.h
+++ b/src/thorin/transform/demote_closures.h
@@ -1,0 +1,14 @@
+#ifndef THORIN_TRANSFORM_DEMOTE_CLOSURES_H
+#define THORIN_TRANSFORM_DEMOTE_CLOSURES_H
+
+#include "thorin/world.h"
+
+namespace thorin {
+
+class World;
+
+bool demote_closures(World& world);
+
+}
+
+#endif

--- a/src/thorin/transform/flatten_tuples.cpp
+++ b/src/thorin/transform/flatten_tuples.cpp
@@ -20,7 +20,7 @@ static const Type* wrapped_type(const FnType* fn_type, size_t max_tuple_size) {
                     nops.push_back(arg);
             } else
                 nops.push_back(op);
-        } else if (auto op_fn_type = op->isa<FnType>()) {
+        } else if (auto op_fn_type = op->isa<FnType>(); op_fn_type && op_fn_type->tag() == NodeTag::Node_FnType) {
             nops.push_back(wrapped_type(op_fn_type, max_tuple_size));
         } else {
             nops.push_back(op);
@@ -98,7 +98,7 @@ static Continuation* wrap_def(Def2Def& wrapped, Def2Def& unwrapped, const Def* o
                 call_args[i + 1] = world.tuple(tuple_args);
             } else
                 call_args[i + 1] = new_cont->param(j++);
-        } else if (auto fn_type = op->isa<FnType>()) {
+        } else if (auto fn_type = op->isa<FnType>(); fn_type && fn_type->tag() == NodeTag::Node_FnType) {
             auto fn_param = new_cont->param(j++);
             // no need to unwrap if the types are identical
             if (fn_param->type() != op)
@@ -149,7 +149,7 @@ static Continuation* unwrap_def(Def2Def& wrapped, Def2Def& unwrapped, const Def*
                     call_args[j++] = world.extract(param, k);
             } else
                 call_args[j++] = param;
-        } else if (auto fn_type = param->type()->isa<FnType>()) {
+        } else if (auto fn_type = param->type()->isa<FnType>(); fn_type && fn_type->tag() == NodeTag::Node_FnType) {
             auto new_fn_type = new_type->op(j - 1)->as<FnType>();
             // no need to wrap if the types are identical
             if (fn_type != new_fn_type)

--- a/src/thorin/transform/importer.cpp
+++ b/src/thorin/transform/importer.cpp
@@ -57,8 +57,8 @@ const Def* Importer::rewrite(const Def* const odef) {
                     // If we don't do so, then we miss some simplifications
                     auto ncallee = instantiate(body->callee());
 
-                    // don't rewrite a continuation as a different type, unless it's only ever called
-                    if (ncallee->type()->tag() == Node_FnType || only_called()) {
+                    // don't rewrite a continuation as a different def, unless it's only ever called
+                    if (ncallee->isa<Continuation>() || only_called()) {
                         src().VLOG("simplify: continuation {} calls a free def: {}", cont->unique_name(), body->callee());
                         return ncallee;
                     }

--- a/src/thorin/transform/importer.cpp
+++ b/src/thorin/transform/importer.cpp
@@ -18,19 +18,6 @@ const Def* Importer::rewrite(const Def* const odef) {
             }
         }
     } else if (auto app = odef->isa<App>()) {
-        // always peel calls to closures
-        if (auto closure = app->callee()->isa<Closure>()) {
-            BetaReducer r(dst());
-            auto fn= import(closure->fn())->as<Continuation>();
-            if (fn->has_body()) {
-                for (size_t i = 0; i < app->args().size(); i++)
-                    r.provide_arg(fn->param(i), import(app->arg(i)));
-                r.provide_arg(fn->params().back(), import(closure));
-                todo_ = true;
-                return r.instantiate(fn->body())->as<App>();
-            }
-        }
-
         // eat calls to known continuations that are only used once
         if (auto callee = app->callee()->isa_nom<Continuation>()) {
             if (callee->has_body() && !src().is_external(callee) && callee->can_be_inlined()) {

--- a/src/thorin/transform/importer.cpp
+++ b/src/thorin/transform/importer.cpp
@@ -31,7 +31,7 @@ const Def* Importer::rewrite(const Def* const odef) {
     } else if (auto closure = odef->isa<Closure>()) {
         bool only_called = true;
         for (auto use : closure->uses()) {
-            if (use.def()->isa<App>() && use.index() == 0)
+            if (use.def()->isa<App>() && use.index() == App::Ops::Callee)
                 continue;
             only_called = false;
             break;
@@ -95,7 +95,7 @@ const Def* Importer::rewrite(const Def* const odef) {
                 // permute the arguments and call the parameter instead
                 for (auto use : cont->copy_uses()) {
                     auto uapp = use->isa<App>();
-                    if (uapp && use.index() == 0) {
+                    if (uapp && use.index() == App::Ops::Callee) {
                         todo_ = true;
                         has_calls = true;
                         break;

--- a/src/thorin/transform/lift.cpp
+++ b/src/thorin/transform/lift.cpp
@@ -419,7 +419,7 @@ const Def* ClosureConverter::ScopeRewriter::rewrite(const Def* const odef) {
                 }
             }
 
-            ncont->set_body(body_rewriter->instantiate(ocont->body())->as<App>());
+            ncont->rebuild_from(*body_rewriter, ocont);
 
             dst().DLOG("finished body of {}", ncont);
         });

--- a/src/thorin/transform/lift.cpp
+++ b/src/thorin/transform/lift.cpp
@@ -301,7 +301,7 @@ const Def* ClosureConverter::ScopeRewriter::rewrite(const Def* const odef) {
                     } else if (param == ncont->ret_param()) {
                         // turn the ret param into a closure
                         // we will undo that with folding ops if it's consumed inside the function
-                        auto captured_ret_param = dst().capture_return(param);
+                        auto captured_ret_param = dst().capture_return(param, ocont->debug());
                         body_rewriter->insert(ocont->ret_param(), captured_ret_param);
                     } else {
                         body_rewriter->insert(ocont->param(i), param);
@@ -319,7 +319,7 @@ const Def* ClosureConverter::ScopeRewriter::rewrite(const Def* const odef) {
                  if (param == ncont->ret_param()) {
                     // turn the ret param into a closure
                     // we will undo that with folding ops if it's consumed inside the function
-                    auto captured_ret_param = dst().capture_return(param);
+                    auto captured_ret_param = dst().capture_return(param, ocont->debug());
                     body_rewriter->insert(ocont->ret_param(), captured_ret_param);
                 } else {
                     body_rewriter->insert(ocont->param(i), param);

--- a/src/thorin/transform/lift.cpp
+++ b/src/thorin/transform/lift.cpp
@@ -57,15 +57,15 @@ struct ClosureConverter {
                     return true;
             }
         }
-        //if (auto tuple = use->isa<Tuple>()) {
-        //    // if the tuple is consumed appropriately, this is OK
-        //    // this is necessary because match() takes tuples nowadays
-        //    for (auto tu : tuple->uses()) {
-        //        if (!is_acceptable_use_for_bb(tu))
-        //            return false;
-        //    }
-        //    return true;
-        //}
+        if (auto tuple = use->isa<Tuple>()) {
+            // if the tuple is consumed appropriately, this is OK
+            // this is necessary because match() takes tuples nowadays
+            for (auto tu : tuple->uses()) {
+                if (!is_acceptable_use_for_bb(tu))
+                    return false;
+            }
+            return true;
+        }
 
         return false;
     }

--- a/src/thorin/transform/lift.cpp
+++ b/src/thorin/transform/lift.cpp
@@ -561,6 +561,7 @@ void lift(Thorin& thorin) {
 
     converter.validate_all_closure_fns_are_top_level();
     validate_all_returning_functions_top_level(*dst);
+    dst->mark_cff(true);
 
     src.swap(dst);
     thorin.cleanup();

--- a/src/thorin/transform/lift.cpp
+++ b/src/thorin/transform/lift.cpp
@@ -1,0 +1,530 @@
+#include "lift.h"
+
+
+#include "thorin/continuation.h"
+#include "thorin/world.h"
+#include "thorin/analyses/scope.h"
+#include "thorin/analyses/cfg.h"
+#include "thorin/transform/rewrite.h"
+
+namespace thorin {
+
+struct ClosureConverter {
+    ClosureConverter(World& src, World& dst, LiftMode mode) : src_(src), dst_(dst), root_rewriter_(*this, nullptr, nullptr), forest_(src), mode_(mode) {
+        assert(&src != &dst);
+    }
+
+    DefSet spillable_free_defs(Continuation* entry, DefSet& additional_rebuild) {
+        DefSet result;
+        unique_queue<DefSet> queue;
+
+        for (auto def: forest_.get_scope(entry).free_frontier())
+            queue.push(def);
+        entry->world().VLOG("Computing free variables for {}", entry);
+
+        while (!queue.empty()) {
+            auto free = queue.pop();
+            assert(!free->type()->isa<MemType>());
+
+            if (free == entry)
+                continue;
+
+            if (auto ret_cont = free->isa<ReturnPoint>()) {
+                assert(false);
+                additional_rebuild.insert(ret_cont);
+                queue.push(ret_cont->continuation());
+                continue;
+            }
+
+            if (auto cont = free->isa_nom<Continuation>()) {
+                if (!should_process(cont) || mode_ == LiftMode::Lift2Cff) {
+                    auto& scope = forest_.get_scope(cont);
+                    if (scope.parent_scope() != nullptr) {
+                        assert(false);
+                        // enforce that this continuation gets rebuilt even though it originally did not belong in the scope
+                        additional_rebuild.insert(cont);
+                        for (auto oparam : cont->params())
+                            additional_rebuild.insert(oparam);
+                        // provide what that continuation will need
+                        auto& frontier = scope.free_frontier();
+                        for (auto def: frontier) {
+                            queue.push(def);
+                        }
+                        entry->world().VLOG("encountered a basic block from a parent scope: {} frontier = {, }", cont, frontier);
+                        continue;
+                    }
+                    entry->world().VLOG("encountered a top level function: {}", cont);
+                    continue;
+                }
+            }
+
+            if (free->has_dep(Dep::Param)) {
+                entry->world().VLOG("fv of {}: {} : {}", entry, free, free->type());
+                result.insert(free);
+            } else
+                free->world().VLOG("ignoring {} because it has no Param dependency", free);
+        }
+
+        return result;
+    }
+
+    struct ScopeRewriter : public Rewriter {
+        ScopeRewriter(ClosureConverter& converter, Scope* scope, ScopeRewriter* parent) : Rewriter(converter.src(), converter.dst()), converter_(converter), parent_(parent), scope_(scope), name_(scope ? scope->entry()->unique_name() : "root") {
+            if (parent)
+                depth_ = parent->depth_ + 1;
+            //assert(depth_ < 4);
+        }
+
+        int depth_ = 0;
+        ClosureConverter& converter_;
+        ScopeRewriter* parent_;
+        Scope* scope_;
+        DefSet additional_;
+        std::vector<std::unique_ptr<ScopeRewriter>> children_;
+        std::string name_;
+
+        const Def* lookup(const thorin::Def* odef) override {
+            auto found = Rewriter::lookup(odef);
+            if (found) return found;
+            if (parent_) return parent_->lookup(odef);
+            return nullptr;
+        }
+
+        const std::string dump() {
+            std::string n = name_;
+            ScopeRewriter* r = parent_;
+            while (r) {
+                n = r->name_ + "::" + n;
+                r = r->parent_;
+            }
+            return n;
+        }
+
+        const Def* rewrite(const Def* odef) override;
+
+        ScopeRewriter(ScopeRewriter&) = delete;
+        ScopeRewriter(ScopeRewriter&&) = delete;
+    };
+
+    ScopeRewriter& root_rewriter() {
+        return root_rewriter_;
+    }
+
+    bool should_process(Continuation* cont) {
+        if (auto found = should_convert_.lookup(cont))
+            return found.value();
+
+        if (cont->is_intrinsic() || cont->is_exported() || !cont->has_body())
+            return false;
+
+        src().DLOG("checking for uses of {} ...", cont);
+        bool needs_lifting = false;
+        bool needs_conversion = false;
+        if (cont->is_returning()) {
+            //src().DLOG("{} is as a returning continuation !", cont);
+            needs_lifting = true;
+        }
+
+        for (auto use : cont->copy_uses()) {
+            if (is_use_first_class(use)) {
+                needs_conversion = true;
+            }
+            if (needs_conversion)
+                break;
+        }
+
+        bool should_process;
+        switch (mode_) {
+            case LiftMode::Lift2Cff:
+                should_process = needs_lifting && !needs_conversion;
+                break;
+            case LiftMode::ClosureConversion:
+                should_process = needs_conversion;
+                break;
+            case LiftMode::JoinTargets:
+                should_process = needs_conversion;
+                break;
+        }
+
+        src().DLOG("should_process({}): {}", cont, should_process);
+        should_convert_.insert(std::make_pair(cont, should_process));
+        return should_process;
+    }
+
+    std::tuple<const Type*, bool> get_env_type(ArrayRef<const Def*> free_vars) {
+        // get the environment type
+        const Type* env_type = nullptr;
+        bool thin_env = free_vars.size() == 1 && is_thin(free_vars[0]->type());
+        if (thin_env) {
+            // optimization: if the environment fits within a pointer or
+            // primitive type, pass it by value.
+            env_type = free_vars[0]->type();
+        } else {
+            Array<const Type*> env_ops(free_vars.size());
+            for (size_t i = 0, e = free_vars.size(); i != e; ++i)
+                env_ops[i] = free_vars[i]->type();
+            env_type = src().tuple_type(env_ops);
+        }
+        return std::make_tuple(env_type, thin_env);
+    }
+
+    std::vector<const Type*> rewrite_params(ScopeRewriter& rewriter, Continuation* ocont) {
+        std::vector<const Type*> nparam_types;
+
+        bool is_accelerator = ocont->is_accelerator();
+        bool acc_body_found = false;
+        for (auto pt : ocont->type()->types()) {
+            const Type* npt = rewriter.instantiate(pt)->as<Type>();
+            // in intrinsics, don't closure-convert immediate parameters
+            if ((ocont->is_intrinsic() && pt->tag() == Node_FnType) && (!is_accelerator || !acc_body_found)) {
+                npt = dst().fn_type(npt->as<FnType>()->types());
+                if (is_accelerator)
+                    acc_body_found = true;
+            }
+            nparam_types.push_back(npt);
+        }
+
+        return nparam_types;
+    }
+
+    Continuation* as_continuation(const Def* ndef) {
+        if (auto found = as_continuations_.lookup(ndef))
+            return found.value();
+
+        if (auto ncont = ndef->isa_nom<Continuation>())
+            return ncont;
+        Debug wr_dbg = ndef->debug();
+        wr_dbg.name += "_wrapped";
+        auto wrapper = dst().continuation(dst().fn_type(ndef->type()->as<FnType>()->types()), wr_dbg);
+        wrapper->jump(ndef, wrapper->params_as_defs());
+        as_continuations_[ndef] = wrapper;
+        return wrapper;
+    }
+
+    bool is_use_first_class(Use& use) {
+        if (use.def()->isa<Param>())
+            return false;
+        if (use.def()->isa<Closure>())
+            return false;
+        if (use.def()->isa<ReturnPoint>())
+            return false;
+        if (auto app = use.def()->isa<App>()) {
+            if (use.index() == App::Ops::Callee)
+                return false;
+            if (auto callee = app->callee()->isa_nom<Continuation>()) {
+                if (callee->is_intrinsic()) {
+                    /*if (mode_ == LiftMode::JoinTargets && callee->intrinsic() == Intrinsic::Control &&
+                        use.index() == App::Ops::FirstArg + 2) {
+                        src().DLOG("{} is used as a join target in {}", use.def()->op(use.index()), app);
+                        return true;
+                    }*/
+                    return false;
+                }
+            }
+        }
+
+        assert(mode_ != LiftMode::JoinTargets && "CC should have been performed earlier...");
+        src().DLOG("{} is used as a first-class value in {} ({}, index={})", use.def()->op(use.index()), use.def(), tag2str(use.def()->tag()), use.index());
+        return true;
+    }
+
+    World& src_;
+    World& dst_;
+    World& src() { return src_; }
+    World& dst() { return dst_; }
+    LiftMode mode_;
+
+    ScopeRewriter root_rewriter_;
+    ScopesForest forest_;
+    ContinuationMap<bool> should_convert_;
+    ContinuationMap<std::vector<const Def*>> lifted_env_;
+    DefMap<Continuation*> as_continuations_;
+    std::vector<std::function<void()>> todo_;
+};
+
+const Def* ClosureConverter::ScopeRewriter::rewrite(const Def* const odef) {
+    assert(&odef->world() == &src());
+    if (parent_) {
+        if (!scope_->contains(odef) && !additional_.contains(odef)) {
+            //dst().DLOG("Deferring rewriting of {} to {}", odef, parent_->name_);
+            return parent_->instantiate(odef);
+        }
+    }
+
+    if (auto fn_type = odef->isa<FnType>()) {
+        if (converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) {
+            Array<const Type*> ntypes(fn_type->num_ops(), [&](int i) {
+                auto old_param_t = fn_type->op(i)->as<Type>();
+                return instantiate(old_param_t)->as<Type>();
+            });
+            if (fn_type->isa<ReturnType>())
+                return dst().return_type(ntypes);
+
+            // Turn all functions into closures, we'll undo it where it is specifically OK
+            auto ntype = dst().closure_type(ntypes);
+            return ntype;
+        }
+    } else if (auto ocont = odef->isa_nom<Continuation>()) {
+        dst().DLOG("analysing '{}' in {}", ocont, dump());
+        auto& scope = converter_.forest_.get_scope(ocont);
+        ScopeRewriter* body_rewriter;
+        const Def* ndef = nullptr;
+        auto nparam_types = converter_.rewrite_params(*this, ocont);
+        if (!converter_.should_process(ocont)) {
+            /*if (converter_.mode_ == LiftMode::JoinTargets && ocont->intrinsic() == Intrinsic::Control) {
+                nparam_types[2] = dst().closure_type(nparam_types[2]->as<FnType>()->types());
+            }*/
+
+            auto ncont = dst().continuation(dst().fn_type(nparam_types), ocont->attributes(), ocont->debug());
+            if ((converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) && !ncont->is_intrinsic()) {
+                Debug tr_debug = ocont->debug();
+                tr_debug.name += "_trampoline";
+                if (tr_debug.name.rfind("llvm", 0) == 0)
+                    tr_debug.name = "_" + tr_debug.name;
+                Continuation* trampoline = dst().continuation(ncont->type(), ncont->attributes(), tr_debug);
+                auto closure_type = dst().closure_type(ncont->type()->types());
+                trampoline->jump(ncont, trampoline->params_as_defs());
+                trampoline->append_param(closure_type);
+                auto closure = dst().closure(closure_type);
+                closure->set_fn(trampoline);
+                closure->set_env(dst().tuple({}));
+                ndef = closure;
+                converter_.as_continuations_[ndef] = ncont;
+            } else {
+                ndef = ncont;
+            }
+            insert(odef, ndef);
+
+            children_.emplace_back(std::make_unique<ScopeRewriter>(converter_, &scope, this));
+            body_rewriter = children_.back().get();
+            body_rewriter->insert(ocont, ncont);
+
+            for (size_t i = 0; i < ocont->num_params(); i++)
+                body_rewriter->insert(ocont->param(i), ncont->param(i));
+            dst().DLOG("no closure generated for '{}' in {}", ocont, dump());
+            converter_.todo_.emplace_back([=]() {
+                ncont->rebuild_from(*body_rewriter, ocont);
+                dst().DLOG("'{}' rebuilt as '{}' in {}", ocont, ncont, dump());
+            });
+        } else {
+            auto ncont = dst().continuation(dst().fn_type(nparam_types), ocont->attributes(), ocont->debug());
+
+            // only the root rewriter is a parent, we're remaking everything else
+            children_.emplace_back(std::make_unique<ScopeRewriter>(converter_, &scope, &converter_.root_rewriter_));
+            body_rewriter = children_.back().get();
+
+            // Compute all the free variables and record additional nodes to be rebuilt in this context
+            std::vector<const Def*> free_vars;
+            for (auto free : converter_.spillable_free_defs(ocont, body_rewriter->additional_)) {
+                if (auto free_cont = free->isa_nom<Continuation>()) {
+                    assert(converter_.should_process(free_cont) && "all spilled continuations should be closure converted too");
+                }
+                free_vars.push_back(free);
+            }
+
+            Closure* closure = nullptr;
+            const Param* closure_param = nullptr;
+            if (converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) {
+                // create a wrapper that takes a pointer to the environment
+                auto closure_type = dst().closure_type(nparam_types);
+                nparam_types.push_back(closure_type);
+                closure_param = ncont->append_param(closure_type, { "self" });
+
+                closure = dst().closure(closure_type, ocont->debug());
+                closure->set_fn(ncont);
+                ndef = closure;
+                insert(ocont, closure);
+                body_rewriter->insert(ocont, closure_param);
+                dst().VLOG("converting '{}' into '{}' in {}", ocont, closure, dump());
+            } else if (!free_vars.empty()) {
+                assert(converter_.mode_ == LiftMode::Lift2Cff);
+                for (auto free_var : free_vars) {
+                    auto captured = ncont->append_param(instantiate(free_var->type())->as<Type>(), ncont->debug());
+                    body_rewriter->insert(free_var, captured);
+                }
+                ncont->jump(ncont, ncont->params_as_defs().get_front(ncont->num_params()));
+
+                converter_.root_rewriter_.insert(ocont, ncont);
+                ndef = ncont;
+                converter_.lifted_env_.emplace(ncont, free_vars);
+            } else {
+                return Rewriter::rewrite(odef);
+            }
+
+            if (!free_vars.empty()) {
+                dst().VLOG("slow: rewriting '{}' as '{}' in {}", ocont, ncont, dump());
+
+                converter_.todo_.emplace_back([=]() {
+                    const Def* new_mem = ncont->mem_param();
+                    auto [env_type, thin] = converter_.get_env_type(free_vars);
+                    env_type = this->instantiate(env_type)->as<Type>();
+
+                    if (converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) {
+                        Array<const Def*> instantiated_free_vars = Array<const Def*>(free_vars.size(), [&](const int i) -> const Def* {
+                            auto env = instantiate(free_vars[i]);
+                            assert(env != closure);
+                            // it cannot be a basic block, and it cannot be top-level either
+                            // if it used to be a continuation it should be a closure now.
+                            assert(!env->isa_nom<Continuation>());
+                            return env;
+                        });
+                        if (thin)
+                            closure->set_env(instantiated_free_vars[0]);
+                        else {
+                            auto env_tuple = dst().tuple(instantiated_free_vars);
+                            if (converter_.mode_ == LiftMode::ClosureConversion) {
+                                closure->set_env(dst().heap_cell(env_tuple));
+                                dst().wdef(ncont, "closure '{}' is leaking memory, type '{}' is too large and must be heap allocated", closure, closure->env()->type());
+                            } else
+                                closure->set_env(dst().stack_cell(env_tuple));
+                        }
+
+                        assert(closure_param);
+                        auto env = dst().extract(closure_param, 1);
+                        if (thin) {
+                            auto captured = dst().cast(this->instantiate(free_vars[0]->type())->as<Type>(), env);
+                            captured->set_name(free_vars[0]->name() + "_captured");
+                            body_rewriter->insert(free_vars[0], captured);
+                        } else {
+                            // make the wrapper load the pointer and pass each
+                            // variable of the environment to the lifted continuation
+                            auto env_ptr = dst().bitcast(Closure::environment_ptr_type(dst()), env);
+                            auto loaded_env = dst().load(ncont->mem_param(), dst().bitcast(dst().ptr_type(env_type), env_ptr));
+                            auto env_data = dst().extract(loaded_env, 1_u32);
+                            new_mem = dst().extract(loaded_env, 0_u32);
+                            for (size_t i = 0, e = free_vars.size(); i != e; ++i) {
+                                auto captured = dst().extract(env_data, i);
+                                captured->set_name(free_vars[i]->name() + "_captured");
+                                body_rewriter->insert(free_vars[i], captured);
+                            }
+                        }
+                    }
+
+                    // Map old arguments to new ones
+                    for (size_t i = 0, e = ocont->num_params(); i != e; ++i) {
+                        auto param = ncont->param(i);
+                        if (ocont->mem_param() == ocont->param(i)) {
+                            // use the mem obtained after the load
+                            body_rewriter->insert(ocont->mem_param(), new_mem);
+                        } else {
+                            body_rewriter->insert(ocont->param(i), param);
+                        }
+                    }
+
+                    ncont->set_body(body_rewriter->instantiate(ocont->body())->as<App>());
+
+                    dst().VLOG("finished body of {}", ncont);
+                });
+            } else if (converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) {
+                dst().DLOG("dummy closure generated for '{}' -> '{}' in {}", ocont, ncont, dump());
+                for (size_t i = 0; i < ocont->num_params(); i++)
+                    body_rewriter->insert(ocont->param(i), ncont->param(i));
+
+                closure->set_env(dst().tuple({}));
+                converter_.todo_.emplace_back([=]() {
+                    ncont->rebuild_from(*body_rewriter, ocont);
+                });
+            }
+        }
+        assert(ndef);
+        return ndef;
+    } else if (auto ret_pt = odef->isa<ReturnPoint>()) {
+        return dst().return_point(converter_.as_continuation(instantiate(ret_pt->continuation())));
+    } else if (auto closure = odef->isa<Closure>()) {
+        auto nclosure = dst().closure(instantiate(closure->type())->as<ClosureType>());
+        insert(odef, nclosure);
+        nclosure->set_fn(converter_.as_continuation(instantiate(closure->fn())));
+        nclosure->set_env(instantiate(closure->env()));
+        return nclosure;
+    } else if (auto app = odef->isa<App>()) {
+        auto ncallee = instantiate(app->callee());
+        if (auto ncont = ncallee->isa_nom<Continuation>(); ncont) {
+            std::vector<const Def*> nargs;
+            nargs.resize(app->num_args());
+
+            for (size_t i = 0; i < app->num_args(); i++) {
+                auto oarg = app->arg(i);
+                if (ncont->is_intrinsic() && ncont->type()->types()[i]->tag() == Node_FnType)
+                    nargs[i] = converter_.as_continuation(instantiate(oarg));
+                else nargs[i] = instantiate(oarg);
+            };
+
+            if (ncont->is_accelerator()) {
+                // there is unfortunately no standardisation on which parameter is the body parameter for accelerators
+                // so we're going to play games here: let's assume only one body is a returning continuation
+                // TODO: make accelerator signatures more consistent
+                Continuation* body = nullptr;
+                size_t body_i;
+                for (size_t i = 0; i < app->num_args(); i++) {
+                    if (auto cont = nargs[i]->isa_nom<Continuation>(); cont && cont->type()->is_returning()) {
+                        assert(!body);
+                        body = cont;
+                        body_i = i;
+                    }
+                }
+                assert(body);
+                auto lifted_body_params = converter_.lifted_env_.lookup(body);
+
+                if (auto extra_params = converter_.lifted_env_.lookup(body); extra_params.has_value()) {
+                    // Update the type of the body parameter
+                    auto ntypes = ncont->type()->copy_types();
+                    ntypes[body_i] = body->type();
+
+                    // Add new parameters to the intrinsic call
+                    Continuation* naccelerator = dst().continuation(dst().fn_type(ntypes), ncont->attributes(), ncont->debug());
+                    for (auto extra : extra_params.value()) {
+                        auto narg = instantiate(extra);
+                        nargs.push_back(narg);
+                        naccelerator->append_param(narg->type());
+                    }
+                    ncallee = naccelerator;
+                }
+            }
+
+            if (auto extra_params = converter_.lifted_env_.lookup(ncont); extra_params.has_value()) {
+                for (auto extra : extra_params.value()) {
+                    nargs.push_back(instantiate(extra));
+                }
+            }
+
+            return dst().app(ncallee, nargs);
+        }
+    }
+    return Rewriter::rewrite(odef);
+}
+
+void validate_all_returning_functions_top_level(World& world) {
+    ScopesForest forest(world);
+    for (auto cont : world.copy_continuations()) {
+        if (cont->type()->is_returning()) {
+            auto parent = forest.get_scope(cont).parent_scope();
+            if (parent != nullptr) {
+                world.ELOG("returning continuation {} is not top-level after closure conversion and belongs to {}'s scope", cont, parent);
+                assert(false);
+            }
+        }
+    }
+}
+
+void lift(Thorin& thorin, LiftMode mode) {
+    auto& src = thorin.world_container();
+    auto dst = std::make_unique<World>(*src);
+    ClosureConverter converter(*src, *dst, mode);
+
+    for (auto& external : src->externals())
+        converter.root_rewriter().instantiate(external.second);
+
+    while (!converter.todo_.empty()) {
+        auto f = converter.todo_.back();
+        converter.todo_.pop_back();
+        f();
+    }
+
+    if (mode >= LiftMode::ClosureConversion)
+        validate_all_returning_functions_top_level(*dst);
+
+    src.swap(dst);
+    thorin.cleanup();
+}
+
+}

--- a/src/thorin/transform/lift.cpp
+++ b/src/thorin/transform/lift.cpp
@@ -10,15 +10,17 @@
 namespace thorin {
 
 struct ClosureConverter {
-    ClosureConverter(World& src, World& dst, LiftMode mode) : src_(src), dst_(dst), root_rewriter_(*this, nullptr, nullptr), forest_(src), mode_(mode) {
+    ClosureConverter(World& src, World& dst) : src_(src), dst_(dst), root_rewriter_(*this, nullptr, nullptr), forest_(src) {
         assert(&src != &dst);
     }
 
-    DefSet spillable_free_defs(Continuation* entry, DefSet& additional_rebuild) {
+    DefSet spillable_free_defs(Continuation* entry) {
         DefSet result;
         unique_queue<DefSet> queue;
 
-        for (auto def: forest_.get_scope(entry).free_frontier())
+        auto& scope = forest_.get_scope(entry);
+
+        for (auto def: scope.free_frontier())
             queue.push(def);
         entry->world().VLOG("Computing free variables for {}", entry);
 
@@ -29,36 +31,17 @@ struct ClosureConverter {
             if (free == entry)
                 continue;
 
-            if (auto ret_cont = free->isa<ReturnPoint>()) {
-                assert(false);
-                additional_rebuild.insert(ret_cont);
-                queue.push(ret_cont->continuation());
-                continue;
-            }
-
             if (auto cont = free->isa_nom<Continuation>()) {
-                if (!should_process(cont) || mode_ == LiftMode::Lift2Cff) {
-                    auto& scope = forest_.get_scope(cont);
-                    if (scope.parent_scope() != nullptr) {
-                        assert(false);
-                        // enforce that this continuation gets rebuilt even though it originally did not belong in the scope
-                        additional_rebuild.insert(cont);
-                        for (auto oparam : cont->params())
-                            additional_rebuild.insert(oparam);
-                        // provide what that continuation will need
-                        auto& frontier = scope.free_frontier();
-                        for (auto def: frontier) {
-                            queue.push(def);
-                        }
-                        entry->world().VLOG("encountered a basic block from a parent scope: {} frontier = {, }", cont, frontier);
-                        continue;
+                // only capture basic blocks - not top level fns
+                // note: capturing basic blocks is bad
+                if (!scope.contains(cont)) {
+                    auto& other_scope = forest_.get_scope(cont);
+                    if (other_scope.parent_scope()) {
+                        entry->world().VLOG("fv (non-top level) of {}: {} : {}", entry, free, free->type());
+                        result.insert(free);
                     }
-                    entry->world().VLOG("encountered a top level function: {}", cont);
-                    continue;
                 }
-            }
-
-            if (free->has_dep(Dep::Param)) {
+            } else if (free->has_dep(Dep::Param)) {
                 entry->world().VLOG("fv of {}: {} : {}", entry, free, free->type());
                 result.insert(free);
             } else
@@ -72,7 +55,6 @@ struct ClosureConverter {
         ScopeRewriter(ClosureConverter& converter, Scope* scope, ScopeRewriter* parent) : Rewriter(converter.src(), converter.dst()), converter_(converter), parent_(parent), scope_(scope), name_(scope ? scope->entry()->unique_name() : "root") {
             if (parent)
                 depth_ = parent->depth_ + 1;
-            //assert(depth_ < 4);
         }
 
         int depth_ = 0;
@@ -110,61 +92,15 @@ struct ClosureConverter {
         return root_rewriter_;
     }
 
-    bool should_process(Continuation* cont) {
-        if (auto found = should_convert_.lookup(cont))
-            return found.value();
-
-        if (cont->is_intrinsic() || cont->is_exported() || !cont->has_body())
-            return false;
-
-        src().DLOG("checking for uses of {} ...", cont);
-        bool needs_lifting = false;
-        bool needs_conversion = false;
-        if (cont->is_returning()) {
-            //src().DLOG("{} is as a returning continuation !", cont);
-            needs_lifting = true;
-        }
-
-        for (auto use : cont->copy_uses()) {
-            if (is_use_first_class(use)) {
-                needs_conversion = true;
-            }
-            if (needs_conversion)
-                break;
-        }
-
-        bool should_process;
-        switch (mode_) {
-            case LiftMode::Lift2Cff:
-                should_process = needs_lifting && !needs_conversion;
-                break;
-            case LiftMode::ClosureConversion:
-                should_process = needs_conversion;
-                break;
-            case LiftMode::JoinTargets:
-                should_process = needs_conversion;
-                break;
-        }
-
-        src().DLOG("should_process({}): {}", cont, should_process);
-        should_convert_.insert(std::make_pair(cont, should_process));
-        return should_process;
-    }
-
     std::tuple<const Type*, bool> get_env_type(ArrayRef<const Def*> free_vars) {
         // get the environment type
         const Type* env_type = nullptr;
         bool thin_env = free_vars.size() == 1 && is_thin(free_vars[0]->type());
-        if (thin_env) {
-            // optimization: if the environment fits within a pointer or
-            // primitive type, pass it by value.
-            env_type = free_vars[0]->type();
-        } else {
-            Array<const Type*> env_ops(free_vars.size());
-            for (size_t i = 0, e = free_vars.size(); i != e; ++i)
-                env_ops[i] = free_vars[i]->type();
-            env_type = src().tuple_type(env_ops);
-        }
+
+        Array<const Type*> env_ops(free_vars.size());
+        for (size_t i = 0, e = free_vars.size(); i != e; ++i)
+            env_ops[i] = free_vars[i]->type();
+        env_type = src().tuple_type(env_ops);
         return std::make_tuple(env_type, thin_env);
     }
 
@@ -194,45 +130,16 @@ struct ClosureConverter {
         if (auto ncont = ndef->isa_nom<Continuation>())
             return ncont;
         Debug wr_dbg = ndef->debug();
-        wr_dbg.name += "_wrapped";
         auto wrapper = dst().continuation(dst().fn_type(ndef->type()->as<FnType>()->types()), wr_dbg);
         wrapper->jump(ndef, wrapper->params_as_defs());
         as_continuations_[ndef] = wrapper;
         return wrapper;
     }
 
-    bool is_use_first_class(Use& use) {
-        if (use.def()->isa<Param>())
-            return false;
-        if (use.def()->isa<Closure>())
-            return false;
-        if (use.def()->isa<ReturnPoint>())
-            return false;
-        if (auto app = use.def()->isa<App>()) {
-            if (use.index() == App::Ops::Callee)
-                return false;
-            if (auto callee = app->callee()->isa_nom<Continuation>()) {
-                if (callee->is_intrinsic()) {
-                    /*if (mode_ == LiftMode::JoinTargets && callee->intrinsic() == Intrinsic::Control &&
-                        use.index() == App::Ops::FirstArg + 2) {
-                        src().DLOG("{} is used as a join target in {}", use.def()->op(use.index()), app);
-                        return true;
-                    }*/
-                    return false;
-                }
-            }
-        }
-
-        assert(mode_ != LiftMode::JoinTargets && "CC should have been performed earlier...");
-        src().DLOG("{} is used as a first-class value in {} ({}, index={})", use.def()->op(use.index()), use.def(), tag2str(use.def()->tag()), use.index());
-        return true;
-    }
-
     World& src_;
     World& dst_;
     World& src() { return src_; }
     World& dst() { return dst_; }
-    LiftMode mode_;
 
     ScopeRewriter root_rewriter_;
     ScopesForest forest_;
@@ -252,190 +159,141 @@ const Def* ClosureConverter::ScopeRewriter::rewrite(const Def* const odef) {
     }
 
     if (auto fn_type = odef->isa<FnType>()) {
-        if (converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) {
-            Array<const Type*> ntypes(fn_type->num_ops(), [&](int i) {
-                auto old_param_t = fn_type->op(i)->as<Type>();
-                return instantiate(old_param_t)->as<Type>();
-            });
-            if (fn_type->isa<ReturnType>())
-                return dst().return_type(ntypes);
+        Array<const Type*> ntypes(fn_type->num_ops(), [&](int i) {
+            auto old_param_t = fn_type->op(i)->as<Type>();
+            return instantiate(old_param_t)->as<Type>();
+        });
+        if (fn_type->isa<ReturnType>())
+            return dst().return_type(ntypes);
 
-            // Turn all functions into closures, we'll undo it where it is specifically OK
-            auto ntype = dst().closure_type(ntypes);
-            return ntype;
-        }
+        // Turn all functions into closures, we'll undo it where it is specifically OK
+        auto ntype = dst().closure_type(ntypes);
+        return ntype;
     } else if (auto ocont = odef->isa_nom<Continuation>()) {
-        dst().DLOG("analysing '{}' in {}", ocont, dump());
+        dst().DLOG("rewriting continuation '{}' in {}", ocont, dump());
         auto& scope = converter_.forest_.get_scope(ocont);
+        assert(scope.parent_scope() == (scope_ ? scope_->entry() : nullptr));
+
+        if (ocont->is_intrinsic()) {
+            return Rewriter::rewrite(ocont);
+        }
+
         ScopeRewriter* body_rewriter;
         const Def* ndef = nullptr;
         auto nparam_types = converter_.rewrite_params(*this, ocont);
-        if (!converter_.should_process(ocont)) {
-            /*if (converter_.mode_ == LiftMode::JoinTargets && ocont->intrinsic() == Intrinsic::Control) {
-                nparam_types[2] = dst().closure_type(nparam_types[2]->as<FnType>()->types());
-            }*/
+        auto ncont = dst().continuation(dst().fn_type(nparam_types), ocont->attributes(), ocont->debug());
 
-            auto ncont = dst().continuation(dst().fn_type(nparam_types), ocont->attributes(), ocont->debug());
-            if ((converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) && !ncont->is_intrinsic()) {
-                Debug tr_debug = ocont->debug();
-                tr_debug.name += "_trampoline";
-                if (tr_debug.name.rfind("llvm", 0) == 0)
-                    tr_debug.name = "_" + tr_debug.name;
-                Continuation* trampoline = dst().continuation(ncont->type(), ncont->attributes(), tr_debug);
-                auto closure_type = dst().closure_type(ncont->type()->types());
-                trampoline->jump(ncont, trampoline->params_as_defs());
-                trampoline->append_param(closure_type);
-                auto closure = dst().closure(closure_type);
-                closure->set_fn(trampoline);
-                closure->set_env(dst().tuple({}));
-                ndef = closure;
-                converter_.as_continuations_[ndef] = ncont;
-            } else {
-                ndef = ncont;
+        // only the root rewriter is a parent, we're remaking everything else
+        children_.emplace_back(std::make_unique<ScopeRewriter>(converter_, &scope, this));
+        body_rewriter = children_.back().get();
+
+        // Compute all the free variables and record additional nodes to be rebuilt in this context
+        std::vector<const Def*> free_vars;
+        for (auto free : converter_.spillable_free_defs(ocont)) {
+            if (auto free_cont = free->isa_nom<Continuation>()) {
+                //assert(converter_.should_process(free_cont) && "all spilled continuations should be closure converted too");
             }
-            insert(odef, ndef);
+            free_vars.push_back(free);
+        }
 
-            children_.emplace_back(std::make_unique<ScopeRewriter>(converter_, &scope, this));
-            body_rewriter = children_.back().get();
-            body_rewriter->insert(ocont, ncont);
+        Closure* closure = nullptr;
+        const Param* closure_param = nullptr;
 
-            for (size_t i = 0; i < ocont->num_params(); i++)
-                body_rewriter->insert(ocont->param(i), ncont->param(i));
-            dst().DLOG("no closure generated for '{}' in {}", ocont, dump());
+        auto closure_type = dst().closure_type(nparam_types);
+
+        // add a 'self' parameter to everything we're allowed to mess with
+        if (!ocont->is_external()) {
+            nparam_types.push_back(closure_type);
+            closure_param = ncont->append_param(closure_type, {"self"});
+        }
+
+        closure = dst().closure(closure_type, ocont->debug());
+        closure->set_fn(ncont);
+        ndef = closure;
+        insert(ocont, closure);
+        // what to use as the closure internally
+        // if the closure captured something, we want to use the param
+        // if it captures nothing, we can use it directly
+        const Def* internal_closure = closure;
+        if (!free_vars.empty())
+            internal_closure = closure_param;
+        body_rewriter->insert(ocont, internal_closure);
+        dst().VLOG("converting '{}' into '{}' in {}", ocont, closure, dump());
+
+        if (!free_vars.empty()) {
+            // can't CC exported continuations
+            assert(!ocont->is_exported());
+            dst().VLOG("slow: rewriting '{}' as '{}' in {}", ocont, ncont, dump());
+
             converter_.todo_.emplace_back([=]() {
-                ncont->rebuild_from(*body_rewriter, ocont);
-                dst().DLOG("'{}' rebuilt as '{}' in {}", ocont, ncont, dump());
+                const Def* new_mem = ncont->mem_param();
+                auto [env_type, thin] = converter_.get_env_type(free_vars);
+                env_type = this->instantiate(env_type)->as<Type>();
+
+                Array<const Def*> instantiated_free_vars = Array<const Def*>(free_vars.size(), [&](const int i) -> const Def* {
+                    auto env = instantiate(free_vars[i]);
+                    assert(env != closure);
+                    // it cannot be a basic block, and it cannot be top-level either
+                    // if it used to be a continuation it should be a closure now.
+                    assert(!env->isa_nom<Continuation>());
+                    return env;
+                });
+
+
+                auto env_tuple = dst().tuple(instantiated_free_vars);
+                closure->set_env(env_tuple);
+                //closure->set_env(dst().heap_cell(env_tuple));
+                //dst().wdef(ncont, "closure '{}' is leaking memory, type '{}' is too large and must be heap allocated", closure, closure->env()->type());
+
+                assert(closure_param);
+                auto env = dst().extract(closure_param, 1);
+
+                // make the wrapper load the pointer and pass each
+                // variable of the environment to the lifted continuation
+                auto env_ptr = dst().bitcast(Closure::environment_ptr_type(dst()), env);
+                //auto loaded_env = dst().load(ncont->mem_param(), dst().bitcast(dst().ptr_type(env_type), env_ptr));
+                auto loaded_env = dst().closure_env(env_type, ncont->mem_param(), closure_param);
+                auto env_data = dst().extract(loaded_env, 1_u32);;
+                //auto env_data = env;
+                new_mem = dst().extract(loaded_env, 0_u32);
+                for (size_t i = 0, e = free_vars.size(); i != e; ++i) {
+                    auto captured = dst().extract(env_data, i);
+                    captured->set_name(free_vars[i]->name() + "_captured");
+                    body_rewriter->insert(free_vars[i], captured);
+                }
+
+                // Map old arguments to new ones
+                for (size_t i = 0, e = ocont->num_params(); i != e; ++i) {
+                    auto param = ncont->param(i);
+                    if (ocont->mem_param() == ocont->param(i)) {
+                        // use the mem obtained after the load
+                        body_rewriter->insert(ocont->mem_param(), new_mem);
+                    } else {
+                        body_rewriter->insert(ocont->param(i), param);
+                    }
+                }
+
+                ncont->set_body(body_rewriter->instantiate(ocont->body())->as<App>());
+
+                dst().VLOG("finished body of {}", ncont);
             });
         } else {
-            auto ncont = dst().continuation(dst().fn_type(nparam_types), ocont->attributes(), ocont->debug());
+            dst().DLOG("dummy closure generated for '{}' -> '{}' in {}", ocont, ncont, dump());
+            for (size_t i = 0; i < ocont->num_params(); i++)
+                body_rewriter->insert(ocont->param(i), ncont->param(i));
 
-            // only the root rewriter is a parent, we're remaking everything else
-            children_.emplace_back(std::make_unique<ScopeRewriter>(converter_, &scope, &converter_.root_rewriter_));
-            body_rewriter = children_.back().get();
-
-            // Compute all the free variables and record additional nodes to be rebuilt in this context
-            std::vector<const Def*> free_vars;
-            for (auto free : converter_.spillable_free_defs(ocont, body_rewriter->additional_)) {
-                if (auto free_cont = free->isa_nom<Continuation>()) {
-                    assert(converter_.should_process(free_cont) && "all spilled continuations should be closure converted too");
-                }
-                free_vars.push_back(free);
-            }
-
-            Closure* closure = nullptr;
-            const Param* closure_param = nullptr;
-            if (converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) {
-                // create a wrapper that takes a pointer to the environment
-                auto closure_type = dst().closure_type(nparam_types);
-                nparam_types.push_back(closure_type);
-                closure_param = ncont->append_param(closure_type, { "self" });
-
-                closure = dst().closure(closure_type, ocont->debug());
-                closure->set_fn(ncont);
-                ndef = closure;
-                insert(ocont, closure);
-                body_rewriter->insert(ocont, closure_param);
-                dst().VLOG("converting '{}' into '{}' in {}", ocont, closure, dump());
-            } else if (!free_vars.empty()) {
-                assert(converter_.mode_ == LiftMode::Lift2Cff);
-                for (auto free_var : free_vars) {
-                    auto captured = ncont->append_param(instantiate(free_var->type())->as<Type>(), ncont->debug());
-                    body_rewriter->insert(free_var, captured);
-                }
-                ncont->jump(ncont, ncont->params_as_defs().get_front(ncont->num_params()));
-
-                converter_.root_rewriter_.insert(ocont, ncont);
-                ndef = ncont;
-                converter_.lifted_env_.emplace(ncont, free_vars);
-            } else {
-                return Rewriter::rewrite(odef);
-            }
-
-            if (!free_vars.empty()) {
-                dst().VLOG("slow: rewriting '{}' as '{}' in {}", ocont, ncont, dump());
-
-                converter_.todo_.emplace_back([=]() {
-                    const Def* new_mem = ncont->mem_param();
-                    auto [env_type, thin] = converter_.get_env_type(free_vars);
-                    env_type = this->instantiate(env_type)->as<Type>();
-
-                    if (converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) {
-                        Array<const Def*> instantiated_free_vars = Array<const Def*>(free_vars.size(), [&](const int i) -> const Def* {
-                            auto env = instantiate(free_vars[i]);
-                            assert(env != closure);
-                            // it cannot be a basic block, and it cannot be top-level either
-                            // if it used to be a continuation it should be a closure now.
-                            assert(!env->isa_nom<Continuation>());
-                            return env;
-                        });
-                        if (thin)
-                            closure->set_env(instantiated_free_vars[0]);
-                        else {
-                            auto env_tuple = dst().tuple(instantiated_free_vars);
-                            if (converter_.mode_ == LiftMode::ClosureConversion) {
-                                closure->set_env(dst().heap_cell(env_tuple));
-                                dst().wdef(ncont, "closure '{}' is leaking memory, type '{}' is too large and must be heap allocated", closure, closure->env()->type());
-                            } else
-                                closure->set_env(dst().stack_cell(env_tuple));
-                        }
-
-                        assert(closure_param);
-                        auto env = dst().extract(closure_param, 1);
-                        if (thin) {
-                            auto captured = dst().cast(this->instantiate(free_vars[0]->type())->as<Type>(), env);
-                            captured->set_name(free_vars[0]->name() + "_captured");
-                            body_rewriter->insert(free_vars[0], captured);
-                        } else {
-                            // make the wrapper load the pointer and pass each
-                            // variable of the environment to the lifted continuation
-                            auto env_ptr = dst().bitcast(Closure::environment_ptr_type(dst()), env);
-                            auto loaded_env = dst().load(ncont->mem_param(), dst().bitcast(dst().ptr_type(env_type), env_ptr));
-                            auto env_data = dst().extract(loaded_env, 1_u32);
-                            new_mem = dst().extract(loaded_env, 0_u32);
-                            for (size_t i = 0, e = free_vars.size(); i != e; ++i) {
-                                auto captured = dst().extract(env_data, i);
-                                captured->set_name(free_vars[i]->name() + "_captured");
-                                body_rewriter->insert(free_vars[i], captured);
-                            }
-                        }
-                    }
-
-                    // Map old arguments to new ones
-                    for (size_t i = 0, e = ocont->num_params(); i != e; ++i) {
-                        auto param = ncont->param(i);
-                        if (ocont->mem_param() == ocont->param(i)) {
-                            // use the mem obtained after the load
-                            body_rewriter->insert(ocont->mem_param(), new_mem);
-                        } else {
-                            body_rewriter->insert(ocont->param(i), param);
-                        }
-                    }
-
-                    ncont->set_body(body_rewriter->instantiate(ocont->body())->as<App>());
-
-                    dst().VLOG("finished body of {}", ncont);
-                });
-            } else if (converter_.mode_ == LiftMode::ClosureConversion || converter_.mode_ == LiftMode::JoinTargets) {
-                dst().DLOG("dummy closure generated for '{}' -> '{}' in {}", ocont, ncont, dump());
-                for (size_t i = 0; i < ocont->num_params(); i++)
-                    body_rewriter->insert(ocont->param(i), ncont->param(i));
-
-                closure->set_env(dst().tuple({}));
-                converter_.todo_.emplace_back([=]() {
-                    ncont->rebuild_from(*body_rewriter, ocont);
-                });
-            }
+            closure->set_env(dst().tuple({}));
+            converter_.todo_.emplace_back([=]() {
+                ncont->rebuild_from(*body_rewriter, ocont);
+            });
         }
+
         assert(ndef);
         return ndef;
     } else if (auto ret_pt = odef->isa<ReturnPoint>()) {
         return dst().return_point(converter_.as_continuation(instantiate(ret_pt->continuation())));
     } else if (auto closure = odef->isa<Closure>()) {
-        auto nclosure = dst().closure(instantiate(closure->type())->as<ClosureType>());
-        insert(odef, nclosure);
-        nclosure->set_fn(converter_.as_continuation(instantiate(closure->fn())));
-        nclosure->set_env(instantiate(closure->env()));
-        return nclosure;
+        assert(false);
     } else if (auto app = odef->isa<App>()) {
         auto ncallee = instantiate(app->callee());
         if (auto ncont = ncallee->isa_nom<Continuation>(); ncont) {
@@ -506,10 +364,10 @@ void validate_all_returning_functions_top_level(World& world) {
     }
 }
 
-void lift(Thorin& thorin, LiftMode mode) {
+void lift(Thorin& thorin) {
     auto& src = thorin.world_container();
     auto dst = std::make_unique<World>(*src);
-    ClosureConverter converter(*src, *dst, mode);
+    ClosureConverter converter(*src, *dst);
 
     for (auto& external : src->externals())
         converter.root_rewriter().instantiate(external.second);
@@ -520,8 +378,7 @@ void lift(Thorin& thorin, LiftMode mode) {
         f();
     }
 
-    if (mode >= LiftMode::ClosureConversion)
-        validate_all_returning_functions_top_level(*dst);
+    validate_all_returning_functions_top_level(*dst);
 
     src.swap(dst);
     thorin.cleanup();

--- a/src/thorin/transform/lift.cpp
+++ b/src/thorin/transform/lift.cpp
@@ -220,7 +220,7 @@ const Def* ClosureConverter::ScopeRewriter::rewrite(const Def* const odef) {
         }
 
         closure = dst().closure(closure_type, ocont->debug());
-        closure->set_fn(ncont);
+        closure->set_fn(ncont, closure_param ? (int) closure_param->index() : -1);
         ndef = closure;
         insert(ocont, closure);
         // what to use as the closure internally

--- a/src/thorin/transform/lift.cpp
+++ b/src/thorin/transform/lift.cpp
@@ -518,8 +518,7 @@ const Def* ClosureConverter::ScopeRewriter::rewrite(const Def* const odef) {
                     // function arguments to accelerators have to be left alone,
                     // but it's easier to let them be closure converted and undo it by lambda lifting
                     // and dropping the closure inside the wrapper
-                    if (i == kernel_i) {
-                        auto closure = nargs[kernel_i]->as<Closure>();
+                    if (i == kernel_i) if (auto closure = nargs[kernel_i]->isa<Closure>()) {
                         auto& free_vars = converter_.lookup(old_body).free_vars;
                         Array<const Type*> instantiated_free_vars = Array<const Type*>(free_vars.size(), [&](const int i) -> const Type* {
                             return instantiate(free_vars[i]->type())->as<Type>();

--- a/src/thorin/transform/lift.h
+++ b/src/thorin/transform/lift.h
@@ -1,0 +1,13 @@
+#include "thorin/world.h"
+
+namespace thorin {
+
+enum LiftMode {
+    Lift2Cff,
+    ClosureConversion,
+    JoinTargets
+};
+
+void lift(Thorin&, LiftMode mode);
+
+}

--- a/src/thorin/transform/lift.h
+++ b/src/thorin/transform/lift.h
@@ -2,12 +2,6 @@
 
 namespace thorin {
 
-enum LiftMode {
-    Lift2Cff,
-    ClosureConversion,
-    JoinTargets
-};
-
-void lift(Thorin&, LiftMode mode);
+void lift(Thorin&);
 
 }

--- a/src/thorin/transform/lower_closure_env.cpp
+++ b/src/thorin/transform/lower_closure_env.cpp
@@ -1,0 +1,58 @@
+#include "lower_closure_env.h"
+
+#include "thorin/transform/rewrite.h"
+
+namespace thorin {
+
+struct LowerClosureEnv : public Rewriter {
+    LowerClosureEnv(World& src, World& dst) : Rewriter(src, dst) {}
+
+    const Def* rewrite(const thorin::Def* odef) override {
+        if (auto oclosure = odef->isa_nom<Closure>()) {
+            auto nclosure = dst().closure(instantiate(oclosure->type())->as<ClosureType>(), oclosure->debug());
+            insert(oclosure, nclosure);
+            nclosure->set_fn(instantiate(oclosure->fn())->as_nom<Continuation>(), oclosure->self_param());
+            auto env_type = instantiate(oclosure->env()->type())->as<Type>();
+            auto nenv = instantiate(oclosure->env());
+            if (is_thin(env_type)) {
+                nclosure->set_env(nenv);
+            } else {
+                dst().WLOG("bad: leaking closure environment for: '{}'", oclosure);
+                nclosure->set_env(dst().heap_cell(nenv));
+            }
+            return nclosure;
+        } else if (auto oenv = odef->isa<ClosureEnv>()) {
+            auto nclosure = instantiate(oenv->op(1));
+            auto nmem = instantiate(oenv->mem());
+            auto env_type = instantiate(oenv->env_type())->as<Type>();
+            const Def* nenv;
+            if (is_thin(env_type)) {
+                nenv = dst().bitcast(env_type, dst().extract(nclosure, 1));
+            } else {
+                auto ptr = dst().bitcast(dst().ptr_type(env_type), dst().extract(nclosure, 1));
+                auto load = dst().load(nmem, ptr);
+                nenv = load->out(1);
+                nmem = load->out(0);
+            }
+
+            assert(nenv->type() == env_type);
+
+            return dst().tuple({nmem, nenv});
+        }
+        return Rewriter::rewrite(odef);
+    }
+};
+
+void lower_closure_env(thorin::Thorin& thorin) {
+    thorin.world().VLOG("start lower_closure_env");
+    auto& src = thorin.world();
+    auto destination = std::make_unique<World>(src);
+    LowerClosureEnv pass(src, *destination.get());
+
+    pass.rewrite_externals();
+
+    thorin.world_container().swap(destination);
+    thorin.world().VLOG("end lower_closure_env");
+}
+
+}

--- a/src/thorin/transform/lower_closure_env.h
+++ b/src/thorin/transform/lower_closure_env.h
@@ -1,0 +1,7 @@
+#include "thorin/world.h"
+
+namespace thorin {
+
+void lower_closure_env(Thorin&);
+
+}

--- a/src/thorin/transform/mangle.h
+++ b/src/thorin/transform/mangle.h
@@ -7,27 +7,30 @@
 
 namespace thorin {
 
-class Mangler : Rewriter {
+class Mangler : public Rewriter {
 public:
-    Mangler(const Scope& scope, Continuation* entry, Defs args, Defs lift);
+    Mangler(const Scope& scope, Continuation* entry, Defs args);
 
     const Scope& scope() const { return scope_; }
     Continuation* mangle();
     Continuation* old_entry() const { return old_entry_; }
     Continuation* new_entry() const { return new_entry_; }
 
-private:
+    void add_to_scope(const Def*);
+    const Def* add_param(const Type*);
+
     const Def* rewrite(const Def* odef) override;
+private:
     bool within(const Def* def) { return scope().contains(def) || defs_.contains(def); }
 
     bool is_dropping_;
 
     const Scope& scope_;
     Defs args_;
-    Defs lift_;
     Continuation* old_entry_;
     Continuation* new_entry_;
     DefSet defs_;
+    std::vector<const Def*> nparams_;
 };
 
 

--- a/src/thorin/transform/rewrite.h
+++ b/src/thorin/transform/rewrite.h
@@ -16,12 +16,9 @@ public:
     World& src() { return src_; }
     World& dst() { return dst_; }
 
-    void rewrite_world() {
+    void rewrite_externals() {
         for (auto&& [_, def] : src().externals()) {
-            if (auto cont = def->isa<Continuation>(); cont && cont->is_exported())
-                instantiate(cont);
-            if (auto global = def->isa<Global>(); global && global->is_external())
-                instantiate(global);
+            instantiate(def);
         }
     }
 

--- a/src/thorin/transform/rewrite.h
+++ b/src/thorin/transform/rewrite.h
@@ -16,6 +16,15 @@ public:
     World& src() { return src_; }
     World& dst() { return dst_; }
 
+    void rewrite_world() {
+        for (auto&& [_, def] : src().externals()) {
+            if (auto cont = def->isa<Continuation>(); cont && cont->is_exported())
+                instantiate(cont);
+            if (auto global = def->isa<Global>(); global && global->is_external())
+                instantiate(global);
+        }
+    }
+
 protected:
     explicit Rewriter(World& src, World& dst, Rewriter& parent);
     virtual const Def* lookup(const Def* odef);

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -267,6 +267,8 @@ inline bool is_thin(const Type* type) {
     return type->isa<PrimType>() || type->isa<PtrType>() || is_type_unit(type);
 }
 
+class ReturnType;
+
 class FnType : public Type, public TypeOpsMixin<FnType> {
 protected:
     FnType(World& world, Defs ops, NodeTag tag, Debug dbg)
@@ -277,7 +279,12 @@ protected:
 
 public:
     bool is_basicblock() const { return order() == 1; }
-    bool is_returning() const;
+    bool is_returning() const { return ret_param_index() >= 0; }
+    const ReturnType* return_param_type() const;
+    int ret_param_index() const;
+
+    Array<const Type*> domain() const;
+    std::optional<Array<const Type*>> codomain() const;
 
 private:
     const Type* rebuild(World&, const Type*, Defs) const override;
@@ -300,6 +307,17 @@ public:
 
 private:
     int inner_order_;
+
+    friend class World;
+};
+
+class ReturnType : public FnType {
+private:
+    ReturnType(World& world, Defs ops, Debug dbg) : FnType(world, ops, Node_ReturnType, dbg) {}
+
+public:
+    const Type* rebuild(World&, const Type*, Defs) const override;
+    const Type* mangle_for_codegen() const;
 
     friend class World;
 };

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -59,11 +59,20 @@ template<class T>
 class TypeOpsMixin {
 public:
     Types types() const {
-        Defs defs = static_cast<const T*>(this)->ops();
+        auto it = static_cast<const T*>(this);
+        Defs defs = it->ops();
         const Def* const* ptr = defs.begin();
         auto ptr2 = reinterpret_cast<const Type* const*>(ptr);
         auto types = Types(ptr2, defs.size());
         return types;
+    }
+
+    Array<const Type*> copy_types() const {
+        auto it = static_cast<const T*>(this);
+        auto copy = Array<const Type*>(it->num_ops(), [&](int i) -> const Type* {
+            return it->op(i)->template as<Type>();
+        });
+        return copy;
     }
 };
 

--- a/src/thorin/util/scoped_dump.cpp
+++ b/src/thorin/util/scoped_dump.cpp
@@ -16,6 +16,11 @@ void ScopedWorld::stream_cont(thorin::Stream& s, Continuation* cont) const {
         default: s.fmt("cc(?)"); break;
     }
 
+    const Def* filter = cont->filter();
+    if (filter && !filter->empty()) {
+        s.fmt("{} ", filter);
+    }
+
     s.fmt(Green);
     s.fmt("cont ");
     s.fmt(Reset);

--- a/src/thorin/util/scoped_dump.cpp
+++ b/src/thorin/util/scoped_dump.cpp
@@ -129,8 +129,11 @@ void ScopedWorld::stream_def(thorin::Stream& s, const thorin::Def* def) const {
         return;
     }
     if (def->isa_nom()) {
-        s.fmt("{}", def->unique_name());
-        return;
+        if (nom_done_.contains(def)) {
+            s.fmt("{}", def->unique_name());
+            return;
+        }
+        nom_done_.insert(def);
     }
 
     s.fmt(Green);

--- a/src/thorin/util/scoped_dump.h
+++ b/src/thorin/util/scoped_dump.h
@@ -31,6 +31,7 @@ struct ScopedWorld : public Streamable<ScopedWorld> {
 
     mutable DefSet done_;
     mutable ContinuationMap<std::unique_ptr<std::vector<const Def*>>> scopes_to_defs_;
+    mutable DefSet nom_done_;
     mutable std::vector<const Def*> top_lvl_;
     Config config_;
 

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1154,6 +1154,14 @@ const Filter* World::filter(const Defs defs, Debug dbg) {
 
 /// App node does its own folding during construction, and it only sets the ops once
 const App* World::app(const Def* callee, const Defs args, Debug dbg) {
+    while (true) {
+        if (auto ret = callee->isa<ReturnPoint>()) {
+            callee = ret->continuation();
+            continue;
+        }
+        break;
+    }
+
     if (auto continuation = callee->isa<Continuation>()) {
         switch (continuation->intrinsic()) {
             // See also mangle::instantiate when modifying this.

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1175,10 +1175,10 @@ const App* World::app(const Def* callee, const Defs args, Debug dbg) {
         }
         if (auto closure = callee->isa<Closure>()) {
             // closures calls without self params can be eliminated
-            if (closure->self_param() < 0) {
-                callee = closure->fn();
-                continue;
-            }
+            //if (closure->self_param() < 0) {
+            //    callee = closure->fn();
+            //    continue;
+            //}
         }
         break;
     }

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -31,6 +31,7 @@
 #include "thorin/transform/flatten_tuples.h"
 #include "thorin/transform/hoist_enters.h"
 #include "thorin/transform/inliner.h"
+#include "thorin/transform/lift.h"
 #include "thorin/transform/lift_builtins.h"
 #include "thorin/transform/partial_evaluation.h"
 #include "thorin/transform/split_slots.h"
@@ -1344,15 +1345,17 @@ void Thorin::opt() {
 }
 
     RUN_PASS(cleanup())
-    RUN_PASS(while (partial_evaluation(world(), true))); // lower2cff
+    //RUN_PASS(while (partial_evaluation(world(), true))); // lower2cff
     RUN_PASS(flatten_tuples(*this))
     RUN_PASS(split_slots(*this))
-    RUN_PASS(closure_conversion(world()))
-    RUN_PASS(lift_builtins(*this))
+    //RUN_PASS(closure_conversion(world()))
+    //RUN_PASS(lift_builtins(*this))
     RUN_PASS(inliner(*this))
     RUN_PASS(hoist_enters(*this))
     RUN_PASS(dead_load_opt(world()))
-    RUN_PASS(cleanup())
+    //RUN_PASS(cleanup())
+    RUN_PASS(lift(*this, LiftMode::Lift2Cff));
+    RUN_PASS(lift(*this, LiftMode::ClosureConversion));
     RUN_PASS(codegen_prepare(*this))
 }
 

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1056,8 +1056,10 @@ const Def* World::alloc(const Type* type, const Def* mem, const Def* extra, Debu
 }
 
 const Def* World::closure_env(const Type* type, const thorin::Def* mem, const thorin::Def* src, thorin::Debug dbg) {
-    if (auto closure = src->isa<Closure>())
+    if (auto closure = src->isa<Closure>()) {
+        assert(closure->env()->type() == type);
         return tuple({mem, closure->env()});
+    }
     return cse(new ClosureEnv(*this, type, mem, src, dbg));
 }
 

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1207,6 +1207,7 @@ const Def* World::return_point(const thorin::Continuation* destination, thorin::
     // but we're wrapping the cont here so we can do just that!
     if (destination->has_body()) {
         auto dbody = destination->body();
+        assert(dbody->callee() != destination);
         if (dbody->callee()->type()->isa<ReturnType>() && dbody->args() == destination->params_as_defs()) {
             Scope s((Continuation*) destination);
             if (!s.contains(dbody->callee())) {

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1174,7 +1174,7 @@ const App* World::app(const Def* callee, const Defs args, Debug dbg) {
             continue;
         }
         if (auto closure = callee->isa<Closure>()) {
-            // closures without self params can be eliminated
+            // closures calls without self params can be eliminated
             if (closure->self_param() < 0) {
                 callee = closure->fn();
                 continue;

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1054,6 +1054,12 @@ const Def* World::alloc(const Type* type, const Def* mem, const Def* extra, Debu
     return cse(new Alloc(*this, type, mem, extra, dbg));
 }
 
+const Def* World::closure_env(const Type* type, const thorin::Def* mem, const thorin::Def* src, thorin::Debug dbg) {
+    if (auto closure = src->isa<Closure>())
+        return tuple({mem, closure->env()});
+    return cse(new ClosureEnv(*this, type, mem, src, dbg));
+}
+
 const Def* World::global(const Def* init, bool is_mutable, Debug dbg) {
     return cse(new Global(*this, init, is_mutable, dbg));
 }
@@ -1350,12 +1356,11 @@ void Thorin::opt() {
     RUN_PASS(split_slots(*this))
     //RUN_PASS(closure_conversion(world()))
     //RUN_PASS(lift_builtins(*this))
-    RUN_PASS(inliner(*this))
+    //RUN_PASS(inliner(*this))
     RUN_PASS(hoist_enters(*this))
     RUN_PASS(dead_load_opt(world()))
     //RUN_PASS(cleanup())
-    RUN_PASS(lift(*this, LiftMode::Lift2Cff));
-    RUN_PASS(lift(*this, LiftMode::ClosureConversion));
+    RUN_PASS(lift(*this));
     RUN_PASS(codegen_prepare(*this))
 }
 

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1173,6 +1173,13 @@ const App* World::app(const Def* callee, const Defs args, Debug dbg) {
             callee = capture->op(0);
             continue;
         }
+        if (auto closure = callee->isa<Closure>()) {
+            // closures without self params can be eliminated
+            if (closure->self_param() < 0) {
+                callee = closure->fn();
+                continue;
+            }
+        }
         break;
     }
 

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1185,10 +1185,10 @@ const App* World::app(const Def* callee, const Defs args, Debug dbg) {
         }
     }
 
-    Array<const Def*> ops(1 + args.size());
-    ops[0] = callee;
+    Array<const Def*> ops(App::Ops::FirstArg + args.size());
+    ops[App::Ops::Callee] = callee;
     for (size_t i = 0; i < args.size(); i++)
-        ops[i + 1] = args[i];
+        ops[App::Ops::FirstArg + i] = args[i];
 
     return cse(new App(*this, ops, dbg));
 }

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -34,6 +34,7 @@
 #include "thorin/transform/lift.h"
 #include "thorin/transform/lift_builtins.h"
 #include "thorin/transform/partial_evaluation.h"
+#include "thorin/transform/lower_closure_env.h"
 #include "thorin/transform/split_slots.h"
 #include "thorin/util/array.h"
 
@@ -1354,13 +1355,14 @@ void Thorin::opt() {
     //RUN_PASS(while (partial_evaluation(world(), true))); // lower2cff
     RUN_PASS(flatten_tuples(*this))
     RUN_PASS(split_slots(*this))
+    RUN_PASS(lift(*this));
     //RUN_PASS(closure_conversion(world()))
     //RUN_PASS(lift_builtins(*this))
     //RUN_PASS(inliner(*this))
     RUN_PASS(hoist_enters(*this))
     RUN_PASS(dead_load_opt(world()))
+    RUN_PASS(lower_closure_env(*this));
     //RUN_PASS(cleanup())
-    RUN_PASS(lift(*this));
     RUN_PASS(codegen_prepare(*this))
 }
 

--- a/src/thorin/world.cpp
+++ b/src/thorin/world.cpp
@@ -1228,7 +1228,7 @@ const Def* World::return_point(const thorin::Continuation* destination, thorin::
     // but we're wrapping the cont here so we can do just that!
     if (destination->has_body()) {
         auto dbody = destination->body();
-        assert(dbody->callee() != destination);
+        //assert(dbody->callee() != destination);
 
         auto can_eta_reduce = [&]() -> bool {
             if (dbody->args() == destination->params_as_defs()) {

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -196,7 +196,7 @@ public:
     const Def* variant_index  (const Def* value, Debug dbg = {});
     const Def* variant_extract(const Def* value, size_t index, Debug dbg = {});
 
-    const Def* closure(const ClosureType* closure_type, const Def* fn, const Def* env, Debug dbg = {}) { return cse(new Closure(*this, closure_type, fn, env, dbg)); }
+    Closure* closure(const ClosureType* closure_type, Debug dbg = {}) { return put<Closure>(*this, closure_type, dbg); }
     const Def* vector(Defs args, Debug dbg = {}) {
         if (args.size() == 1) return args[0];
         return try_fold_aggregate(cse(new Vector(*this, args, dbg)));
@@ -251,6 +251,8 @@ public:
     const Def* slot(const Type* type, const Def* frame, Debug dbg = {}) { return cse(new Slot(*this, type, frame, dbg)); }
     const Def* alloc(const Type* type, const Def* mem, const Def* extra, Debug dbg = {});
     const Def* alloc(const Type* type, const Def* mem, Debug dbg = {}) { return alloc(type, mem, literal_qu64(0, dbg), dbg); }
+    const Def* heap_cell(const Def* contents, Debug dbg = {}) { return cse(new Cell(*this, ptr_type(contents->type()), contents, true, dbg)); }
+    const Def* stack_cell(const Def* contents, Debug dbg = {}) { return cse(new Cell(*this, ptr_type(contents->type()), contents, false, dbg)); }
     const Def* global(const Def* init, bool is_mutable = true, Debug dbg = {});
     const Def* global_immutable_string(const std::string& str, Debug dbg = {});
     const Def* lea(const Def* ptr, const Def* index, Debug dbg);

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -124,6 +124,7 @@ public:
     const FnType* fn_type() { return fn_type({}); } ///< Returns an empty @p FnType.
     const FnType* fn_type(Types args);
     const ClosureType* closure_type(Types args);
+    const ReturnType* return_type(Types args);
     const DefiniteArrayType*   definite_array_type(const Type* elem, u64 dim);
     const IndefiniteArrayType* indefinite_array_type(const Type* elem);
 
@@ -275,6 +276,7 @@ public:
     Continuation* match(const Type* type, size_t num_patterns);
     Continuation* end_scope() const { return data_.end_scope_; }
     const App* app(const Def* callee, const Defs args, Debug dbg = {});
+    const ReturnPoint* return_point(const Continuation* destination, Debug dbg = {}) { return cse(new ReturnPoint(*this, destination, dbg)); }
     const Filter* filter(const Defs, Debug dbg = {});
 
     // getters

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -280,6 +280,8 @@ public:
     Continuation* end_scope() const { return data_.end_scope_; }
     const App* app(const Def* callee, const Defs args, Debug dbg = {});
     const Def* return_point(const Continuation* destination, Debug dbg = {});
+    /// turns a return value into a closure, which can be captured (return values cannot be captured)
+    const Def* capture_return(const Def* ret, Debug dbg = {}) { return cse(new CaptureReturn(*this, ret, dbg)); }
     const Filter* filter(const Defs, Debug dbg = {});
 
     // getters

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -297,6 +297,12 @@ public:
     bool is_pe_done() const { return state_.pe_done; }
     //@}
 
+    /// @name CFF
+    //@{
+    void mark_cff(bool flag = true) { state_.cff = flag; }
+    bool is_cff() const { return state_.cff; }
+    //@}
+
 #if THORIN_ENABLE_CHECKS
     /// @name debugging features
     //@{
@@ -380,6 +386,7 @@ private:
         LogLevel min_level = LogLevel::Error;
         u32 cur_gid = 0;
         bool pe_done = false;
+        bool cff = false;
 #if THORIN_ENABLE_CHECKS
         bool track_history = false;
         Breakpoints breakpoints;

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -251,6 +251,7 @@ public:
     const Def* slot(const Type* type, const Def* frame, Debug dbg = {}) { return cse(new Slot(*this, type, frame, dbg)); }
     const Def* alloc(const Type* type, const Def* mem, const Def* extra, Debug dbg = {});
     const Def* alloc(const Type* type, const Def* mem, Debug dbg = {}) { return alloc(type, mem, literal_qu64(0, dbg), dbg); }
+    const Def* closure_env(const Type* env_type, const Def* mem, const Def* closure, Debug dbg = {});
     const Def* heap_cell(const Def* contents, Debug dbg = {}) { return cse(new Cell(*this, ptr_type(contents->type()), contents, true, dbg)); }
     const Def* stack_cell(const Def* contents, Debug dbg = {}) { return cse(new Cell(*this, ptr_type(contents->type()), contents, false, dbg)); }
     const Def* global(const Def* init, bool is_mutable = true, Debug dbg = {});

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -276,7 +276,7 @@ public:
     Continuation* match(const Type* type, size_t num_patterns);
     Continuation* end_scope() const { return data_.end_scope_; }
     const App* app(const Def* callee, const Defs args, Debug dbg = {});
-    const ReturnPoint* return_point(const Continuation* destination, Debug dbg = {}) { return cse(new ReturnPoint(*this, destination, dbg)); }
+    const Def* return_point(const Continuation* destination, Debug dbg = {});
     const Filter* filter(const Defs, Debug dbg = {});
 
     // getters


### PR DESCRIPTION
Addresses https://github.com/AnyDSL/thorin/issues/178, https://github.com/AnyDSL/thorin/issues/137, https://github.com/AnyDSL/thorin/issues/95 and probably many others !

This implements lambda lifting and closure conversion in one package. This is mature enough to compile aobench and all the new tests added in https://github.com/AnyDSL/artic/pull/34 - except for the accelerator tests for now