### PR TITLE
Feature/extern type

### DIFF
--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -369,6 +369,11 @@ std::string CCodeGen::convert(const Type* type) {
             s.rangei(struct_type->ops(), "\n", [&] (size_t i) { s.fmt("{} {};", convert(struct_type->types()[i]), struct_type->op_name(i)); });
             s.fmt("\b\n}} {};\n", name);
         }
+    } else if (auto extern_type = type->isa<ExternType>()) {
+        name = extern_type->name().str();
+        assert(extern_type->args().size() == 1 && "External type in C backend unsupported.");
+        auto first_arg = extern_type->args()[0];
+        s.fmt("typedef {} {};", first_arg, name);
     } else {
         THORIN_UNREACHABLE;
     }

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -373,7 +373,7 @@ std::string CCodeGen::convert(const Type* type) {
         name = extern_type->name().str();
         assert(extern_type->args().size() == 1 && "External type in C backend unsupported.");
         auto first_arg = extern_type->args()[0];
-        s.fmt("typedef {} {};", first_arg, name);
+        s.fmt("typedef {} {};\n", first_arg, name);
     } else {
         THORIN_UNREACHABLE;
     }

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -370,11 +370,16 @@ std::string CCodeGen::convert(const Type* type) {
             s.fmt("\b\n}} {};\n", name);
         }
     } else if (auto extern_type = type->isa<ExternType>()) {
-        types_[extern_type] = name = extern_type->name().str();
-        assert(extern_type->num_ops() == 1 && "External type in C backend unsupported.");
-        auto first_arg = extern_type->op(0);
-        assert(first_arg->isa<DefiniteArray>() && "Only strings as argument.");
-        s.fmt("typedef {} {};\n", first_arg->as<DefiniteArray>()->as_string(), name);
+        if (extern_type->name() == "c.typedef") {
+            types_[extern_type] = name = extern_type->unique_name();
+            assert(extern_type->num_ops() == 1 && "External type in C backend unsupported.");
+            auto first_arg = extern_type->op(0);
+            assert(first_arg->isa<DefiniteArray>() && "Only strings as argument.");
+            s.fmt("typedef {} {};\n", first_arg->as<DefiniteArray>()->as_string(), name);
+        } else {
+            world().edef(extern_type, "unsupported extern_type");
+            s.fmt("/* unsupported */");
+        }
     } else {
         THORIN_UNREACHABLE;
     }

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -371,8 +371,8 @@ std::string CCodeGen::convert(const Type* type) {
         }
     } else if (auto extern_type = type->isa<ExternType>()) {
         name = extern_type->name().str();
-        assert(extern_type->ops().size() == 1 && "External type in C backend unsupported.");
-        auto first_arg = extern_type->ops()[0];
+        assert(extern_type->ext_args().size() == 1 && "External type in C backend unsupported.");
+        auto first_arg = extern_type->ext_args()[0];
         assert(first_arg->isa<DefiniteArray>() && "Only strings as argument.");
         s.fmt("typedef {} {};\n", first_arg->as<DefiniteArray>()->as_string(), name);
     } else {

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -370,9 +370,9 @@ std::string CCodeGen::convert(const Type* type) {
             s.fmt("\b\n}} {};\n", name);
         }
     } else if (auto extern_type = type->isa<ExternType>()) {
-        name = extern_type->name().str();
-        assert(extern_type->ext_args().size() == 1 && "External type in C backend unsupported.");
-        auto first_arg = extern_type->ext_args()[0];
+        types_[extern_type] = name = extern_type->name().str();
+        assert(extern_type->num_ops() == 1 && "External type in C backend unsupported.");
+        auto first_arg = extern_type->op(0);
         assert(first_arg->isa<DefiniteArray>() && "Only strings as argument.");
         s.fmt("typedef {} {};\n", first_arg->as<DefiniteArray>()->as_string(), name);
     } else {

--- a/src/thorin/be/c/c.cpp
+++ b/src/thorin/be/c/c.cpp
@@ -371,9 +371,10 @@ std::string CCodeGen::convert(const Type* type) {
         }
     } else if (auto extern_type = type->isa<ExternType>()) {
         name = extern_type->name().str();
-        assert(extern_type->args().size() == 1 && "External type in C backend unsupported.");
-        auto first_arg = extern_type->args()[0];
-        s.fmt("typedef {} {};\n", first_arg, name);
+        assert(extern_type->ops().size() == 1 && "External type in C backend unsupported.");
+        auto first_arg = extern_type->ops()[0];
+        assert(first_arg->isa<DefiniteArray>() && "Only strings as argument.");
+        s.fmt("typedef {} {};\n", first_arg->as<DefiniteArray>()->as_string(), name);
     } else {
         THORIN_UNREACHABLE;
     }

--- a/src/thorin/rec_stream.cpp
+++ b/src/thorin/rec_stream.cpp
@@ -234,6 +234,9 @@ Stream& Type::stream(Stream& s) const {
 
         if (t->is_vector()) s.fmt(">");
         return s;
+    } else if (auto t = isa<ExternType>()) {
+        s.fmt("{}", t->name());
+        return s;
     }
     THORIN_UNREACHABLE;
 }

--- a/src/thorin/tables/nodetable.h
+++ b/src/thorin/tables/nodetable.h
@@ -57,6 +57,7 @@
         THORIN_NODE(Lambda, lambda)
         THORIN_NODE(MemType, mem)
         THORIN_NODE(BotType, bot_ty)
+        THORIN_NODE(ExternType, ext_ty)
         THORIN_NODE(PtrType, ptr)
         THORIN_NODE(StructType, struct_type)
         THORIN_NODE(VariantType, variant_type)

--- a/src/thorin/transform/closure_conversion.cpp
+++ b/src/thorin/transform/closure_conversion.cpp
@@ -205,6 +205,14 @@ public:
             // struct types cannot be rebuilt and need to be put in the map first to avoid infinite recursion
             new_type = world_.struct_type(type->as<StructType>()->name(), ops.size());
             new_types_[type] = new_type;
+        } else if (type->isa<VariantType>()) {
+            // struct types cannot be rebuilt and need to be put in the map first to avoid infinite recursion
+            new_type = world_.variant_type(type->as<VariantType>()->name(), ops.size());
+            new_types_[type] = new_type;
+        } else if (type->isa<ExternType>()) {
+            // struct types cannot be rebuilt and need to be put in the map first to avoid infinite recursion
+            new_type = world_.extern_type(type->as<ExternType>()->name(), ops.size());
+            new_types_[type] = new_type;
         }
 
         // accept one parameter of order 1 (the return continuation) for function types
@@ -223,6 +231,14 @@ public:
             StructType* struct_type = const_cast<StructType*>(new_type->as<StructType>());
             for (size_t i = 0, e = ops.size(); i != e; ++i)
                 struct_type->set_op(i, ops[i]);
+        } else if (type->isa<VariantType>()) {
+            VariantType* variant_type = const_cast<VariantType*>(new_type->as<VariantType>());
+            for (size_t i = 0, e = ops.size(); i != e; ++i)
+                variant_type->set_op(i, ops[i]);
+        } else if (type->isa<ExternType>()) {
+            ExternType* extern_type = const_cast<ExternType*>(new_type->as<ExternType>());
+            for (size_t i = 0, e = ops.size(); i != e; ++i)
+                extern_type->set_op(i, ops[i]);
         } else {
             new_type = type->rebuild(world_, type->type(), ops)->as<Type>();
         }

--- a/src/thorin/type.cpp
+++ b/src/thorin/type.cpp
@@ -61,7 +61,6 @@ const Type* MemType            ::rebuild(World& w, const Type*  , Defs  ) const 
 const Type* PrimType           ::rebuild(World& w, const Type*  , Defs  ) const { return w.prim_type(primtype_tag(), length()); }
 const Type* PtrType            ::rebuild(World& w, const Type*  , Defs o) const { return w.ptr_type(o[0]->as<Type>(), length(), addr_space()); }
 const Type* TupleType          ::rebuild(World& w, const Type*  , Defs o) const { return w.tuple_type(defs2types(o)); }
-const Type* ExternType         ::rebuild(World& w, const Type*  , Defs  ) const { return w.extern_type(name(), args()); }
 
 /*
  * stub
@@ -77,6 +76,10 @@ VariantType* VariantType::stub(Rewriter& rewriter, const Type*) const {
     auto type = rewriter.dst().variant_type(name(), num_ops());
     std::copy(op_names_.begin(), op_names_.end(), type->op_names().begin());
     return type;
+}
+
+ExternType* ExternType::stub(Rewriter& rewriter, const Type*) const {
+    return rewriter.dst().extern_type(name(), args());
 }
 
 //------------------------------------------------------------------------------
@@ -156,6 +159,10 @@ StructType* World::struct_type(Symbol name, size_t size) {
 
 VariantType* World::variant_type(Symbol name, size_t size) {
     return put<VariantType>(*this, name, size, Debug());
+}
+
+ExternType* World::extern_type(Symbol name, std::vector<std::string> args) {
+    return put<ExternType>(*this, name, args, Debug());
 }
 
 const PrimType* World::prim_type(PrimTypeTag tag, size_t length) {

--- a/src/thorin/type.cpp
+++ b/src/thorin/type.cpp
@@ -61,6 +61,7 @@ const Type* MemType            ::rebuild(World& w, const Type*  , Defs  ) const 
 const Type* PrimType           ::rebuild(World& w, const Type*  , Defs  ) const { return w.prim_type(primtype_tag(), length()); }
 const Type* PtrType            ::rebuild(World& w, const Type*  , Defs o) const { return w.ptr_type(o[0]->as<Type>(), length(), addr_space()); }
 const Type* TupleType          ::rebuild(World& w, const Type*  , Defs o) const { return w.tuple_type(defs2types(o)); }
+const Type* ExternType         ::rebuild(World& w, const Type*  , Defs  ) const { return w.extern_type(name(), args()); }
 
 /*
  * stub

--- a/src/thorin/type.cpp
+++ b/src/thorin/type.cpp
@@ -79,7 +79,11 @@ VariantType* VariantType::stub(Rewriter& rewriter, const Type*) const {
 }
 
 ExternType* ExternType::stub(Rewriter& rewriter, const Type*) const {
-    return rewriter.dst().extern_type(name(), args());
+    Array<const Def*> new_ops(ops().size());
+    int i = 0;
+    for (auto o : ops())
+        new_ops[i++] = rewriter.instantiate(o);
+    return rewriter.dst().extern_type(name(), new_ops);
 }
 
 //------------------------------------------------------------------------------
@@ -161,8 +165,8 @@ VariantType* World::variant_type(Symbol name, size_t size) {
     return put<VariantType>(*this, name, size, Debug());
 }
 
-ExternType* World::extern_type(Symbol name, std::vector<std::string> args) {
-    return put<ExternType>(*this, name, args, Debug());
+ExternType* World::extern_type(Symbol name, Defs ops) {
+    return put<ExternType>(*this, name, ops, Debug());
 }
 
 const PrimType* World::prim_type(PrimTypeTag tag, size_t length) {

--- a/src/thorin/type.cpp
+++ b/src/thorin/type.cpp
@@ -79,12 +79,7 @@ VariantType* VariantType::stub(Rewriter& rewriter, const Type*) const {
 }
 
 ExternType* ExternType::stub(Rewriter& rewriter, const Type*) const {
-    Array<const Def*> new_args(ext_args().size());
-    int i = 0;
-    for (auto arg : ext_args()) {
-        new_args[i++] = rewriter.instantiate(arg);
-    }
-    return rewriter.dst().extern_type(name(), new_args);
+    return rewriter.dst().extern_type(name(), num_ops());
 }
 
 //------------------------------------------------------------------------------
@@ -166,8 +161,8 @@ VariantType* World::variant_type(Symbol name, size_t size) {
     return put<VariantType>(*this, name, size, Debug());
 }
 
-ExternType* World::extern_type(Symbol name, Defs ext_args) {
-    return put<ExternType>(*this, name, ext_args, Debug());
+ExternType* World::extern_type(Symbol name, size_t size) {
+    return put<ExternType>(*this, name, size, Debug());
 }
 
 const PrimType* World::prim_type(PrimTypeTag tag, size_t length) {

--- a/src/thorin/type.cpp
+++ b/src/thorin/type.cpp
@@ -79,11 +79,12 @@ VariantType* VariantType::stub(Rewriter& rewriter, const Type*) const {
 }
 
 ExternType* ExternType::stub(Rewriter& rewriter, const Type*) const {
-    Array<const Def*> new_ops(ops().size());
+    Array<const Def*> new_args(ext_args().size());
     int i = 0;
-    for (auto o : ops())
-        new_ops[i++] = rewriter.instantiate(o);
-    return rewriter.dst().extern_type(name(), new_ops);
+    for (auto arg : ext_args()) {
+        new_args[i++] = rewriter.instantiate(arg);
+    }
+    return rewriter.dst().extern_type(name(), new_args);
 }
 
 //------------------------------------------------------------------------------
@@ -165,8 +166,8 @@ VariantType* World::variant_type(Symbol name, size_t size) {
     return put<VariantType>(*this, name, size, Debug());
 }
 
-ExternType* World::extern_type(Symbol name, Defs ops) {
-    return put<ExternType>(*this, name, ops, Debug());
+ExternType* World::extern_type(Symbol name, Defs ext_args) {
+    return put<ExternType>(*this, name, ext_args, Debug());
 }
 
 const PrimType* World::prim_type(PrimTypeTag tag, size_t length) {

--- a/src/thorin/type.cpp
+++ b/src/thorin/type.cpp
@@ -79,7 +79,7 @@ VariantType* VariantType::stub(Rewriter& rewriter, const Type*) const {
 }
 
 ExternType* ExternType::stub(Rewriter& rewriter, const Type*) const {
-    return rewriter.dst().extern_type(name(), num_ops());
+    return rewriter.dst().extern_type(name(), num_ops(), debug());
 }
 
 //------------------------------------------------------------------------------
@@ -161,8 +161,8 @@ VariantType* World::variant_type(Symbol name, size_t size) {
     return put<VariantType>(*this, name, size, Debug());
 }
 
-ExternType* World::extern_type(Symbol name, size_t size) {
-    return put<ExternType>(*this, name, size, Debug());
+ExternType* World::extern_type(Symbol name, size_t size, Debug dbg) {
+    return put<ExternType>(*this, name, size, dbg);
 }
 
 const PrimType* World::prim_type(PrimTypeTag tag, size_t length) {

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -133,6 +133,23 @@ public:
     friend class World;
 };
 
+class ExternType : public NominalType {
+private:
+    ExternType(World& world, Symbol name, std::vector<std::string> args, Debug dbg)
+        : NominalType(world, Node_ExternType, name, 0, dbg)
+        , args_(args)
+    {}
+
+    std::vector<std::string> args_;
+
+public:
+    virtual ExternType* stub(Rewriter&, const Type*) const override;
+
+    std::vector<std::string> args() const { return args_; }
+
+    friend class World;
+};
+
 /// The type of the memory monad.
 class MemType : public Type {
 private:
@@ -151,26 +168,6 @@ private:
     BottomType(World& world, Debug dbg)
         : Type(world, Node_BotType, Defs(), dbg)
     {}
-
-    const Type* rebuild(World&, const Type*, Defs) const override;
-
-    friend class World;
-};
-
-class ExternType : public Type {
-private:
-    ExternType(World& world, Symbol name, std::vector<std::string> args, Debug dbg)
-        : Type(world, Node_ExternType, Defs(), dbg)
-        , name_(name)
-        , args_(args)
-    {}
-
-    Symbol name_;
-    std::vector<std::string> args_;
-
-public:
-    Symbol name() const { return name_; }
-    std::vector<std::string> args() const { return args_; }
 
     const Type* rebuild(World&, const Type*, Defs) const override;
 

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -157,6 +157,26 @@ private:
     friend class World;
 };
 
+class ExternType : public Type {
+private:
+    ExternType(World& world, Symbol name, std::vector<std::string> args, Debug dbg)
+        : Type(world, Node_ExternType, Defs(), dbg)
+        , name_(name)
+        , args_(args)
+    {}
+
+    Symbol name_;
+    std::vector<std::string> args_;
+
+public:
+    Symbol name() const { return name_; }
+    std::vector<std::string> args() const { return args_; }
+
+    const Type* rebuild(World&, const Type*, Defs) const override;
+
+    friend class World;
+};
+
 /// The type of a stack frame.
 class FrameType : public Type {
 private:

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -135,17 +135,17 @@ public:
 
 class ExternType : public NominalType {
 private:
-    ExternType(World& world, Symbol name, Defs ops, Debug dbg)
+    ExternType(World& world, Symbol name, Defs ext_args, Debug dbg)
         : NominalType(world, Node_ExternType, name, 0, dbg)
-        , ops_(ops)
+        , ext_args_(ext_args)
     {}
 
-    Defs ops_;
+    Defs ext_args_;
 
 public:
     virtual ExternType* stub(Rewriter&, const Type*) const override;
 
-    Defs ops() const { return ops_; }
+    Defs ext_args() const { return ext_args_; }
 
     friend class World;
 };

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -135,17 +135,17 @@ public:
 
 class ExternType : public NominalType {
 private:
-    ExternType(World& world, Symbol name, std::vector<std::string> args, Debug dbg)
+    ExternType(World& world, Symbol name, Defs ops, Debug dbg)
         : NominalType(world, Node_ExternType, name, 0, dbg)
-        , args_(args)
+        , ops_(ops)
     {}
 
-    std::vector<std::string> args_;
+    Defs ops_;
 
 public:
     virtual ExternType* stub(Rewriter&, const Type*) const override;
 
-    std::vector<std::string> args() const { return args_; }
+    Defs ops() const { return ops_; }
 
     friend class World;
 };

--- a/src/thorin/type.h
+++ b/src/thorin/type.h
@@ -135,17 +135,11 @@ public:
 
 class ExternType : public NominalType {
 private:
-    ExternType(World& world, Symbol name, Defs ext_args, Debug dbg)
-        : NominalType(world, Node_ExternType, name, 0, dbg)
-        , ext_args_(ext_args)
-    {}
-
-    Defs ext_args_;
+    ExternType(World& world, Symbol name, size_t size, Debug dbg)
+        : NominalType(world, Node_ExternType, name, size, dbg) {}
 
 public:
     virtual ExternType* stub(Rewriter&, const Type*) const override;
-
-    Defs ext_args() const { return ext_args_; }
 
     friend class World;
 };

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -116,6 +116,7 @@ public:
 #include "thorin/tables/primtypetable.h"
     const PrimType* prim_type(PrimTypeTag tag, size_t length = 1);
     const BottomType* bottom_type() { return make<BottomType>(*this, Debug()); }
+    const ExternType* extern_type(Symbol name, std::vector<std::string> args) { return make<ExternType>(*this, name, args, Debug()); }
     const MemType* mem_type() { return make<MemType>(*this, Debug()); }
     const FrameType* frame_type() { return make<FrameType>(*this, Debug()); }
     const PtrType* ptr_type(const Type* pointee, size_t length = 1, AddrSpace addr_space = AddrSpace::Generic);

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -110,13 +110,13 @@ public:
     const TupleType* unit_type() { return tuple_type({})->as<TupleType>(); } ///< Returns unit, i.e., an empty @p TupleType.
     VariantType* variant_type(Symbol name, size_t size);
     StructType* struct_type(Symbol name, size_t size);
+    ExternType* extern_type(Symbol name, std::vector<std::string> args);
 
 #define THORIN_ALL_TYPE(T, M) \
     const PrimType* type_##T(size_t length = 1) { return prim_type(PrimType_##T, length); }
 #include "thorin/tables/primtypetable.h"
     const PrimType* prim_type(PrimTypeTag tag, size_t length = 1);
     const BottomType* bottom_type() { return make<BottomType>(*this, Debug()); }
-    const ExternType* extern_type(Symbol name, std::vector<std::string> args) { return make<ExternType>(*this, name, args, Debug()); }
     const MemType* mem_type() { return make<MemType>(*this, Debug()); }
     const FrameType* frame_type() { return make<FrameType>(*this, Debug()); }
     const PtrType* ptr_type(const Type* pointee, size_t length = 1, AddrSpace addr_space = AddrSpace::Generic);

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -110,7 +110,7 @@ public:
     const TupleType* unit_type() { return tuple_type({})->as<TupleType>(); } ///< Returns unit, i.e., an empty @p TupleType.
     VariantType* variant_type(Symbol name, size_t size);
     StructType* struct_type(Symbol name, size_t size);
-    ExternType* extern_type(Symbol name, size_t size);
+    ExternType* extern_type(Symbol name, size_t size, Debug = {});
 
 #define THORIN_ALL_TYPE(T, M) \
     const PrimType* type_##T(size_t length = 1) { return prim_type(PrimType_##T, length); }

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -110,7 +110,7 @@ public:
     const TupleType* unit_type() { return tuple_type({})->as<TupleType>(); } ///< Returns unit, i.e., an empty @p TupleType.
     VariantType* variant_type(Symbol name, size_t size);
     StructType* struct_type(Symbol name, size_t size);
-    ExternType* extern_type(Symbol name, Defs ops);
+    ExternType* extern_type(Symbol name, Defs ext_args);
 
 #define THORIN_ALL_TYPE(T, M) \
     const PrimType* type_##T(size_t length = 1) { return prim_type(PrimType_##T, length); }

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -110,7 +110,7 @@ public:
     const TupleType* unit_type() { return tuple_type({})->as<TupleType>(); } ///< Returns unit, i.e., an empty @p TupleType.
     VariantType* variant_type(Symbol name, size_t size);
     StructType* struct_type(Symbol name, size_t size);
-    ExternType* extern_type(Symbol name, Defs ext_args);
+    ExternType* extern_type(Symbol name, size_t size);
 
 #define THORIN_ALL_TYPE(T, M) \
     const PrimType* type_##T(size_t length = 1) { return prim_type(PrimType_##T, length); }

--- a/src/thorin/world.h
+++ b/src/thorin/world.h
@@ -110,7 +110,7 @@ public:
     const TupleType* unit_type() { return tuple_type({})->as<TupleType>(); } ///< Returns unit, i.e., an empty @p TupleType.
     VariantType* variant_type(Symbol name, size_t size);
     StructType* struct_type(Symbol name, size_t size);
-    ExternType* extern_type(Symbol name, std::vector<std::string> args);
+    ExternType* extern_type(Symbol name, Defs ops);
 
 #define THORIN_ALL_TYPE(T, M) \
     const PrimType* type_##T(size_t length = 1) { return prim_type(PrimType_##T, length); }


### PR DESCRIPTION
https://github.com/AnyDSL/artic/pull/36.

This is the bare minimum required to support external types. The only back-end implementation emits external types in the C backend, only types with a single string literal are supported, and that string literal is dumped into the output file as `typedef <id> <option>;` with `<option>` being the supplied option verbatim. **The option is not sanitized in any way!**