### PR TITLE
Fix Clang compile error "use of overloaded operator '!=' is ambiguous"

### DIFF
--- a/src/thorin/util/hash.h
+++ b/src/thorin/util/hash.h
@@ -351,7 +351,7 @@ public:
             pos.verify();
             assert(pos.table_ == this && "iterator does not match to this table");
             assert(!empty());
-            assert(pos != end() && !is_invalid(pos.ptr_));
+            assert(pos != cend() && !is_invalid(pos.ptr_));
             --size_;
             value_type empty;
             key(&empty) = H::sentinel();


### PR DESCRIPTION
Fixes this error when trying to compile thorin using Clang
```c++
/home/gruen/repos/vscode-artic/artic-lsp/build/_deps/thorin-src/src/thorin/util/hash.h:354:24: error: use of overloaded operator '!=' is ambiguous (with operand types 'thorin::detail::HashTable<std::basic_string<char>, thorin::Def *, thorin::World::ExternalsHash, 4>::const_iterator' (aka 'iterator_base<true>') and 'thorin::detail::HashTable<std::basic_string<char>, thorin::Def *, thorin::World::ExternalsHash, 4>::iterator' (aka 'iterator_base<false>'))
            assert(pos != end() && !is_invalid(pos.ptr_));         
```